### PR TITLE
Support environments

### DIFF
--- a/.env.tmpl
+++ b/.env.tmpl
@@ -2,6 +2,9 @@
 CDF_CLUSTER=westeurope-1
 CDF_URL=https://westeurope-1.cognitedata.com
 CDF_PROJECT=<project>
+# NOTE! The build.py command will set the following environment variables:
+# CDF_ENVIRON = name of the environment (e.g. demo)
+# CDF_BUILD_TYPE = type of the environment (dev, staging, prod)
 IDP_TENANT_ID=
 IDP_CLIENT_ID=<client_id>
 IDP_CLIENT_SECRET=<secret>

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,7 +27,7 @@ jobs:
         run: poetry install
       - name: "Build the package"
         run: |
-          poetry run python build.py
+          poetry run python build.py --env=demo
       - name: "Deploy the package"
         run: |
-          poetry run python deploy.py --drop --drop-data
+          poetry run python deploy.py --drop --drop-data --env=demo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
             "program": "./build.py",
             "args": [
                 "--clean",
+                "--env=local",
                 "build"
             ],
             "console": "integratedTerminal",
@@ -26,6 +27,7 @@
                 //"--dry-run",
                 "--drop",
                 "--drop-data",
+                "--env=dev",
                 "--include=data_models"
             ],
             "console": "integratedTerminal",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "build",
             "type": "shell",
-            "command": "./build.py --clean"
+            "command": "./build.py --clean --env=local"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ combination.
 These are the steps to get started with these templates:
 
 1. Create a new repository based on this template.
-2. Edit `local.yaml` to specify the modules you want to deploy.
-3. Edit `config.yaml` to change any global variables you want to change.
+2. Edit `local.yaml` to specify the modules you want to deploy for each environment you deploy to.
+3. Edit `config.yaml` to change any global variables you want to change. If you want environment specific
+   variables, you can prefix the variable name with the environment name, e.g. `prod.my_var: something`
 4. (optional) For each `cdf_*` module, edit the `config.yaml` file to change any variables you want to change.
 5. (optional) Add any modules of your own that you may want to add (don't use `cdf_*` prefix).
-6. Run `./build.py` to create a build/ directory with the configurations.
-7. Run `./deploy.py` to deploy the configurations to your CDF project.
+6. Run `./build.py --env=<demo|local|dev|staging|prod>` to create a build/ directory with the
+   configurations.
+7. Run `./deploy.py --env=<demo|local|dev|staging|prod>` to deploy the configurations to your CDF project.
 
 ## Target usage
 
@@ -145,19 +147,26 @@ template. All your local changes on a per customer/project basis should go into 
 
 ### Templating and configuration
 
-Configuration variables should be defined in `config.yaml` files. The root `config.yaml` file has
-scope for all modules, while each module can have its own `config.yaml` file that is only used for
-that module.
+In `local.yaml`, you specify details on the environments you want to deploy. The `build.py` script will
+set CDF_ENVIRON and CDF_BUILD_TYPE = (dev, staging, prod) as environment variables.
+These can be used in the `config.yaml` files.
+
+Configuration variables used across your module configurations should be defined in `config.yaml` files.
+The root `config.yaml` file has scope for all modules, while each module can have its own `config.yaml` 
+file that is only used for that module.
 
 Template variables in files in the common/ and modules/ directories should be in the form
 `{{variable_name}}`.
 If you want template variables to be replaced by environment variables, use the following format in the
-.yaml file: `variable_name: ${ENV_VAR_NAME}`.
+config.yaml file: `variable_name: ${ENV_VAR_NAME}`.
+If you want variables to be set dependent on the environment you deploy to (e.g. `build.py --env=prod`),
+you can prefix the variable with environment name, e.g. use the following format in the config.yaml file:
+ `prod.variable_name: something`.
 
 > You can also put `config.yaml` files in the
 > `<modules>/<my_module>/`` directory. Any values here have only scope in that module.
 
-The global.yaml and `local.yaml` files are then used by the _build_ step  to
+The global.yaml and `local.yaml` files are used by the _build_ step  to
 process the configurations and create a `build/` directory where all the configurations are
 merged into a single directory structure.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ These are the steps to get started with these templates:
 5. (optional) Add any modules of your own that you may want to add (don't use `cdf_*` prefix).
 6. Run `./build.py --env=<demo|local|dev|staging|prod>` to create a build/ directory with the
    configurations.
-7. Run `./deploy.py --env=<demo|local|dev|staging|prod>` to deploy the configurations to your CDF project.
+7. Copy `.env.tmpl` to .env and edit the file to set the environment variables for your project.
+8. Run `./deploy.py --env=<demo|local|dev|staging|prod>` to deploy the configurations to your CDF project.
 
 ## Target usage
 

--- a/build.py
+++ b/build.py
@@ -14,10 +14,10 @@ log = logging.getLogger(__name__)
 load_dotenv(".env")
 
 
-def run(build_dir: str, clean: bool = False) -> None:
+def run(build_dir: str, build_env: str = "dev", clean: bool = False) -> None:
     print(f"Building config files from templates into {build_dir}...")
 
-    build_config(dir=build_dir, clean=clean)
+    build_config(dir=build_dir, build_env=build_env, clean=clean)
 
 
 if __name__ == "__main__":
@@ -26,12 +26,19 @@ if __name__ == "__main__":
         "build_dir",
         default="./build",
         nargs="?",
-        help="Where to write the config files",
+        help="Where to write the module files to deploy",
     )
     parser.add_argument(
         "--clean",
         action="store_true",
         help="Clean the build directory before building",
     )
+    parser.add_argument(
+        "--env",
+        action="store",
+        nargs="?",
+        default="dev",
+        help="The environment to build for, defaults to dev",
+    )
     args, unknown_args = parser.parse_known_args()
-    run(args.build_dir, clean=args.clean)
+    run(args.build_dir, build_env=args.env, clean=args.clean)

--- a/deploy.py
+++ b/deploy.py
@@ -14,6 +14,7 @@ from scripts.load import (
     load_timeseries_metadata,
     load_transformations,
 )
+from scripts.templates import read_environ_config
 from scripts.utils import CDFToolConfig
 
 log = logging.getLogger(__name__)
@@ -26,12 +27,15 @@ load_dotenv(".env")
 
 def run(
     build_dir: str,
+    build_env: str = "dev",
     drop: bool = True,
     drop_data: bool = False,
     dry_run: bool = True,
     include: Optional[list[str]] = None,
 ) -> None:
-    print(f"Deploying config files from {build_dir}...")
+    # Set environment variables from local.yaml
+    read_environ_config(build_env=build_env)
+    print(f"Deploying config files from {build_dir} to environment {build_env}...")
     # Configure a client and load credentials from environment
     build_path = Path(__file__).parent / build_dir
     if not build_path.is_dir():
@@ -119,6 +123,13 @@ if __name__ == "__main__":
         nargs="?",
         help="Where to pick up the config files to deploy",
     )
+    parser.add_argument(
+        "--env",
+        action="store",
+        nargs="?",
+        default="dev",
+        help="The environment to build for, defaults to dev",
+    )
     args, unknown_args = parser.parse_known_args()
     if args.include is not None:
         include = args.include.split(",")
@@ -126,6 +137,7 @@ if __name__ == "__main__":
         include = None
     run(
         build_dir=args.build_dir,
+        build_env=args.env,
         dry_run=args.dry_run,
         drop=args.drop,
         drop_data=args.drop_data,

--- a/local.yaml
+++ b/local.yaml
@@ -1,4 +1,35 @@
-# This should be a used to specify which modules and packages to deploy locally and in the GitHub Action.
-# You can have multiple deploy commands.
-# Order is important.
-deploy: ["demo_infield", "cdf_apm_simple"]
+# local.yaml should be checked into code repository.
+# It contains the environment definitions to control build and deploy.
+# Use build.sh --env <env> to specify which environment to build and deploy
+# where <env> is the name of one of the below environment in local.yaml (root-level key)
+#
+# Note that the following environment variables will be set:
+# CDF_ENVIRON = name of the environment (e.g. demo)
+# CDF_BUILD_TYPE = type of the environment (dev, staging, prod)
+# 
+# If you set CDF_PROJECT as an environment variable, the environment you are trying to
+# deploy to must have the same project name configured below. This is a safety measure
+# to prevent you from accidentily deploying to the wrong environment.
+demo:
+  project: "project-loader-dev"
+  type: "dev"
+  # This should be a used to specify which modules and packages to deploy locally and in the GitHub Action.
+  # You can have multiple deploy commands.
+  # Order is important.
+  deploy: ["demo_infield", "cdf_apm_simple"]
+local: # Only used for local development and iterations, should not be used in CI/CD
+  project: ""
+  type: "dev"
+  deploy: ["demo_infield", "cdf_apm_simple"]
+dev:
+  project: "<customer>-dev"
+  type: "dev"
+  deploy: []
+staging:
+  project: "<customer>-staging"
+  type: "staging"
+  deploy: []
+prod:
+  project: "<customer>-prod"
+  type: "prod"
+  deploy: []


### PR DESCRIPTION
build.py and deploy.py now support --env=<local|demo|dev|staging|prod>
Default is dev.

local.yaml supports configuration of environments, so you can deploy different modules dependent on environment.

config.yaml files now support prefixed variables with environment: <env>.my_var allowing you to set vars based on environment

CDF_ENVIRON and CDF_BUILD_TYPE are set as environment variables based on the settings in local.yaml.