### PR TITLE
Gtw/diffing of resources

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Build the templates"
         run: cdf-tk build --build-dir=./build --env=demo ./demo_project
       - name: "Verify and create access rights"
-        run: cdf-tk auth verify
+        run: cdf-tk auth verify --create-group=684237e9-c1fd-4d3c-8c50-de9ea30ac16f
       # be careful, this works as promised
       - name: "Delete existing resources including data"
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,4 @@ new_project/
 # If you need to update the cognite_toolkit template files for local.yaml and config.yaml, comment below
 local.yaml
 config.yaml
+demo_project/

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Changes are grouped as follows
+Changes are grouped as follows:
+
 - `Added` for new features.
 - `Changed` for changes in existing functionality.
 - `Deprecated` for soon-to-be removed features.
@@ -13,15 +14,24 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## []
-## Changed
+## [TBD]
+
+### Changed
+
 - Refactored load functionality. Loading raw tables and files now requires a `yaml` file with metadata.
-## Added
+  
+### Added
+
 - Support for loading `data_sets`
+- Support for loading auth without --drop, i.e. `deploy --include=auth` and only changed groups are deployed.
+- `cdf-tk --verbose build` now prints the resolution of modules and packages.
 
 ## [0.1.0a2] - 2023-11-22
+
 ### Fixed
+
 - The `experimental` module was not included when running command `cdf-tk init`. This is now fixed.
 
 ## [0.1.0a1] - 2023-11-21
+
 Initial release

--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Changes are grouped as follows
+Changes are grouped as follows:
+
 - `Added` for new features.
 - `Changed` for changes in existing functionality.
 - `Deprecated` for soon-to-be removed features.
@@ -13,12 +14,20 @@ Changes are grouped as follows
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [] 
-## Changed 
-* `examples/cdf_apm_simple/raw` and `examples/example_dump_asst_hierarchy/raw` now explicitly 
+## [TBD]
+
+### Changed
+
+- `examples/cdf_apm_simple/raw` and `examples/example_dump_asst_hierarchy/raw` now explicitly
   defines database and table name in `.yaml` files for each table.
-* Added `data_set` to `examples/example_dump_asst_hierarchy/`, which was implicitly defined in 
+- Added `data_set` to `examples/example_dump_asst_hierarchy/`, which was implicitly defined in
   before.
 
+### Fixed
+
+- cdf_infield_common module and the auth applications-configuration.yaml did not load group source id
+   correctly due to source_id being used instead of sourceId. This is now fixed.
+
 ## [0.1.0] - 2023-11-21
+
 Initial release

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -116,6 +116,7 @@ def common(
 
 @app.command("build")
 def build(
+    ctx: typer.Context,
     source_dir: Annotated[
         Optional[str],
         typer.Argument(
@@ -158,7 +159,13 @@ def build(
         )
     )
 
-    build_config(build_dir=build_dir, source_dir=source_dir, build_env=build_env, clean=clean)
+    build_config(
+        build_dir=build_dir,
+        source_dir=source_dir,
+        build_env=build_env,
+        clean=clean,
+        verbose=ctx.obj.verbose,
+    )
 
 
 _AVAILABLE_DATA_TYPES: tuple[str] = tuple(
@@ -264,6 +271,7 @@ def deploy(
     print(ToolGlobals.as_string())
     if "auth" in include and (directory := (Path(build_dir) / "auth")).is_dir():
         # First, we need to get all the generic access, so we can create the rest of the resources.
+        print("  [bold]EVALUATING auth resources with ALL scope...[/]")
         drop_load_resources(
             AuthLoader.create_loader(ToolGlobals, target_scopes="all_scoped_only"),
             directory,
@@ -271,6 +279,7 @@ def deploy(
             drop=drop,
             load=True,
             dry_run=dry_run,
+            verbose=ctx.obj.verbose,
         )
         if ToolGlobals.failed:
             print("[bold red]ERROR: [/] Failure to deploy auth as expected.")
@@ -308,12 +317,14 @@ def deploy(
                 drop=drop,
                 load=True,
                 dry_run=dry_run,
+                verbose=ctx.obj.verbose,
             )
             if ToolGlobals.failed:
                 print(f"[bold red]ERROR: [/] Failure to load {LoaderCls.folder_name} as expected.")
                 exit(1)
     if "auth" in include and (directory := (Path(build_dir) / "auth")).is_dir():
         # Last, we need to get all the scoped access, as the resources should now have been created.
+        print("[bold]EVALUATING auth resources scoped to resources...[/]")
         drop_load_resources(
             AuthLoader.create_loader(ToolGlobals, target_scopes="resource_scoped_only"),
             directory,
@@ -321,6 +332,7 @@ def deploy(
             drop=drop,
             load=True,
             dry_run=dry_run,
+            verbose=ctx.obj.verbose,
         )
     if ToolGlobals.failed:
         print("[bold red]ERROR: [/] Failure to deploy auth as expected.")
@@ -455,6 +467,7 @@ def clean(
                 drop=True,
                 load=False,
                 dry_run=dry_run,
+                verbose=ctx.obj.verbose,
             )
             if ToolGlobals.failed:
                 print(f"[bold red]ERROR: [/] Failure to clean {LoaderCls.folder_name} as expected.")
@@ -467,6 +480,7 @@ def clean(
             drop=True,
             load=False,
             dry_run=dry_run,
+            verbose=ctx.obj.verbose,
         )
         if ToolGlobals.failed:
             print("[bold red]ERROR: [/] Failure to clean auth as expected.")

--- a/cognite_toolkit/local.yaml
+++ b/cognite_toolkit/local.yaml
@@ -27,6 +27,7 @@ local:
   project: <customer>-dev
   type: dev
   deploy:
+    - cdf_auth_readwrite_all
     - cdf_apm_base
     - cdf_oid_example_data
     - cdf_infield_common

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/4.ApmConfig.view.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/4.ApmConfig.view.yaml
@@ -1,7 +1,7 @@
 externalId: APM_Config
 name: APM Config
 description: "Config data for APM applications"
-version: 1 # must be this exact version
+version: '1' # must be this exact version
 space: APM_Config # Must be this exact space
 properties:
   name:

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/apm_config.datamodel.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/apm_config.datamodel.yaml
@@ -1,10 +1,10 @@
 externalId: APM_Config
 name: APM config
-version: 1 # must be this exact version
+version: '1' # must be this exact version
 space: APM_Config # Must be this exact space
 description: "Config data for APM applications"
 views:
   - type: view
     externalId: APM_Config
     space: APM_Config # Must be this exact space
-    version: 1 # must be this exact version
+    version: '1' # must be this exact version

--- a/cognite_toolkit/modules/cdf_infield_common/auth/applications-configuration.yaml
+++ b/cognite_toolkit/modules/cdf_infield_common/auth/applications-configuration.yaml
@@ -1,5 +1,5 @@
 name: 'applications-configuration'
-source_id: '{{applicationsconfiguration_source_id}}'
+sourceId: '{{applicationsconfiguration_source_id}}'
 metadata:
   origin: 'cdf-project-templates'
   cdf_template_version: '{{cdf_template_version}}'

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -100,6 +100,7 @@ def test_module_approval(
             mockToolGlobals=cdf_tool,
         )
         build(
+            context,
             source_dir="./cognite_toolkit",
             build_dir=str(local_tmp_path),
             build_env="test",

--- a/tests/test_approval_modules_snapshots/cdf_apm_base.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_apm_base.yaml
@@ -247,31 +247,31 @@ DataModel:
   externalId: APM_Config
   name: APM config
   space: APM_Config
-  version: 1
+  version: '1'
   views:
   - externalId: APM_Config
     space: APM_Config
     type: view
-    version: 1
+    version: '1'
 - description: APM data models for customer source data to be consumed by the APM
     application.
   externalId: APM_SourceData
   name: APM Source data
   space: APM_SourceData
-  version: 1
+  version: '1'
   views:
   - externalId: APM_Activity
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Operation
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Notification
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
 Space:
 - description: Imported space
   name: APM_Config
@@ -338,7 +338,7 @@ View:
         externalId: APM_Notification
         space: APM_SourceData
         type: view
-        version: 1
+        version: '1'
       type:
         externalId: APM_Activity.notifications
         space: APM_SourceData
@@ -397,7 +397,7 @@ View:
       description: Nature of the activity, such as corrective or preventive. Use descriptive
         terms over codes for better UI clarity.
   space: APM_SourceData
-  version: 1
+  version: '1'
 - description: Config data for APM applications
   externalId: APM_Config
   name: APM Config
@@ -447,7 +447,7 @@ View:
       containerPropertyIdentifier: name
       description: Name of the configuration, infield just use one config record
   space: APM_Config
-  version: 1
+  version: '1'
 - description: The Maintenance Notification API informs the maintenance team of anomalies
     in technical objects within the plant. It comprehensively logs tasks for long-term
     analysis and aids in task planning and execution.
@@ -530,7 +530,7 @@ View:
         Request, or Activity Report. Use descriptive types over codes for clarity
         in the UI.
   space: APM_SourceData
-  version: 1
+  version: '1'
 - description: An operation delineates a distinct maintenance task tailored for a
     specific asset, such as gasket replacement, scaffolding setup, or level measurement.
   externalId: APM_Operation
@@ -615,7 +615,7 @@ View:
       containerPropertyIdentifier: title
       description: Brief title or summary of the specified operation.
   space: APM_SourceData
-  version: 1
+  version: '1'
 deleted:
   Container:
   - externalId: APM_Activity
@@ -634,25 +634,25 @@ deleted:
   - externalId: APM_Config
     space: APM_Config
     type: datamodel
-    version: 1
+    version: '1'
   - externalId: APM_SourceData
     space: APM_SourceData
     type: datamodel
-    version: 1
+    version: '1'
   View:
   - externalId: APM_Activity
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Config
     space: APM_Config
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Notification
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Operation
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'

--- a/tests/test_approval_modules_snapshots/cdf_apm_base.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_apm_base.yaml
@@ -258,20 +258,20 @@ DataModel:
   externalId: APM_SourceData
   name: APM Source data
   space: APM_SourceData
-  version: '1'
+  version: 1
   views:
   - externalId: APM_Activity
     space: APM_SourceData
     type: view
-    version: '1'
+    version: 1
   - externalId: APM_Operation
     space: APM_SourceData
     type: view
-    version: '1'
+    version: 1
   - externalId: APM_Notification
     space: APM_SourceData
     type: view
-    version: '1'
+    version: 1
 Space:
 - description: Imported space
   name: APM_Config
@@ -338,7 +338,7 @@ View:
         externalId: APM_Notification
         space: APM_SourceData
         type: view
-        version: '1'
+        version: 1
       type:
         externalId: APM_Activity.notifications
         space: APM_SourceData
@@ -397,7 +397,7 @@ View:
       description: Nature of the activity, such as corrective or preventive. Use descriptive
         terms over codes for better UI clarity.
   space: APM_SourceData
-  version: '1'
+  version: 1
 - description: Config data for APM applications
   externalId: APM_Config
   name: APM Config
@@ -530,7 +530,7 @@ View:
         Request, or Activity Report. Use descriptive types over codes for clarity
         in the UI.
   space: APM_SourceData
-  version: '1'
+  version: 1
 - description: An operation delineates a distinct maintenance task tailored for a
     specific asset, such as gasket replacement, scaffolding setup, or level measurement.
   externalId: APM_Operation
@@ -615,7 +615,7 @@ View:
       containerPropertyIdentifier: title
       description: Brief title or summary of the specified operation.
   space: APM_SourceData
-  version: '1'
+  version: 1
 deleted:
   Container:
   - externalId: APM_Activity
@@ -638,12 +638,12 @@ deleted:
   - externalId: APM_SourceData
     space: APM_SourceData
     type: datamodel
-    version: '1'
+    version: 1
   View:
   - externalId: APM_Activity
     space: APM_SourceData
     type: view
-    version: '1'
+    version: 1
   - externalId: APM_Config
     space: APM_Config
     type: view
@@ -651,8 +651,8 @@ deleted:
   - externalId: APM_Notification
     space: APM_SourceData
     type: view
-    version: '1'
+    version: 1
   - externalId: APM_Operation
     space: APM_SourceData
     type: view
-    version: '1'
+    version: 1

--- a/tests/test_approval_modules_snapshots/cdf_infield_common.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_infield_common.yaml
@@ -20,6 +20,7 @@ Group:
     cdf_template_version: 0.0.1
     origin: cdf-project-templates
   name: applications-configuration
+  sourceId: <change_me>
 Space:
 - description: Space for Infield App Data
   name: cognite_app_data


### PR DESCRIPTION
## Description

- Fix the sourceid in application-configurations group of infield
- Add --verbose to build to see resolving of templates
- Add a compare functionality to the generic loading for auth specifically as a start to only
load the diff if --drop is not specified.

## Checklist:
- [x ] Tests added/updated.
- [x] Documentation updated.
- [ x] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
