### PR TITLE
Gtw/fix_file_409

### DIFF
--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -297,6 +297,7 @@ def deploy(
         load_datamodel(
             ToolGlobals,
             drop=drop,
+            drop_data=drop_data,
             directory=models_dir,
             delete_containers=drop_data,  # Also delete properties that have been ingested (leaving empty instances)
             delete_spaces=drop_data,  # Also delete spaces if there are no empty instances (needs to be deleted separately)
@@ -453,11 +454,24 @@ def clean(
         load_datamodel(
             ToolGlobals,
             drop=True,
+            drop_data=True,
             only_drop=True,
             directory=models_dir,
             delete_removed=True,
-            delete_spaces=True,  # Also delete properties that have been ingested (leaving empty instances)
-            delete_containers=True,  # Also delete spaces if there are no empty instances (needs to be deleted separately)
+            delete_spaces=True,
+            delete_containers=True,
+            dry_run=dry_run,
+        )
+    elif CDFDataTypes.instances in include and (models_dir := Path(f"{build_dir}/data_models")).is_dir():
+        load_datamodel(
+            ToolGlobals,
+            drop=False,
+            drop_data=True,
+            only_drop=True,
+            directory=models_dir,
+            delete_removed=False,
+            delete_spaces=False,
+            delete_containers=False,
             dry_run=dry_run,
         )
     if ToolGlobals.failed:

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -500,6 +500,7 @@ def clean(
             directory,
             ToolGlobals,
             drop=True,
+            clean=True,
             load=False,
             dry_run=dry_run,
             verbose=ctx.obj.verbose,

--- a/cognite_toolkit/cdf_tk/load.py
+++ b/cognite_toolkit/cdf_tk/load.py
@@ -64,7 +64,7 @@ from cognite.client.data_classes.data_modeling import (
     ViewId,
 )
 from cognite.client.data_classes.iam import Group, GroupList
-from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError
+from cognite.client.exceptions import CogniteAPIError, CogniteDuplicatedError, CogniteNotFoundError
 from rich import print
 
 from .delete import delete_instances
@@ -639,10 +639,13 @@ def drop_load_resources(
                 loader.delete(drop_items)
                 if verbose:
                     print(f"  Deleted {len(drop_items)} {loader.api_name}.")
+            except CogniteAPIError as e:
+                if e.code == 404:
+                    print(f"  [bold yellow]WARNING:[/] {len(drop_items)} {loader.api_name} do not exist.")
+            except CogniteNotFoundError:
+                print(f"  [bold yellow]WARNING:[/] {len(drop_items)} {loader.api_name} do not exist.")
             except Exception as e:
-                print(
-                    f"  [bold yellow]WARNING:[/] Failed to delete {len(drop_items)} {loader.api_name}. It/they may not exist. Error {e}"
-                )
+                print(f"  [bold yellow]WARNING:[/] Failed to delete {len(drop_items)} {loader.api_name}. Error {e}")
         else:
             print(f"  Would have deleted {len(drop_items)} {loader.api_name}.")
     if not load:

--- a/cognite_toolkit/examples/cdf_apm_simple_data_model/data_models/apm_simple.space.yaml
+++ b/cognite_toolkit/examples/cdf_apm_simple_data_model/data_models/apm_simple.space.yaml
@@ -1,0 +1,4 @@
+---
+space: {{space}}
+name: {{space}}
+description: Space for APM simple data model

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/1.Activity.view.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/1.Activity.view.yaml
@@ -1,7 +1,7 @@
 externalId: APM_Activity
 name: APM_Activity
 description: "An activity represents a set of maintenance tasks, comprised of multiple operations for individual assets. It provides an overarching description and is considered incomplete until all its operations are finished."
-version: {{apm_datamodel_version}}
+version: '{{apm_datamodel_version}}'
 space: {{apm_datamodel_space}}
 properties:
   id:
@@ -69,7 +69,7 @@ properties:
       type: view
       space: {{apm_datamodel_space}}
       externalId: APM_Notification
-      version: {{apm_datamodel_version}}
+      version: '{{apm_datamodel_version}}'
     direction: outwards
     connectionType: multiEdgeConnection
   rootLocation:

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/2.Operation.view.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/2.Operation.view.yaml
@@ -1,7 +1,7 @@
 externalId: APM_Operation
 name: "APM_Operation"
 description: "An operation delineates a distinct maintenance task tailored for a specific asset, such as gasket replacement, scaffolding setup, or level measurement."
-version: {{apm_datamodel_version}}
+version: '{{apm_datamodel_version}}'
 space: {{apm_datamodel_space}}
 properties:
   id:

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/3.Notification.view.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/3.Notification.view.yaml
@@ -1,7 +1,7 @@
 externalId: APM_Notification
 name: "APM_Notification"
 description: "The Maintenance Notification API informs the maintenance team of anomalies in technical objects within the plant. It comprehensively logs tasks for long-term analysis and aids in task planning and execution."
-version: {{apm_datamodel_version}}
+version: '{{apm_datamodel_version}}'
 space: {{apm_datamodel_space}}
 properties:
   sourceId:

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/APM_Config.space.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/APM_Config.space.yaml
@@ -1,0 +1,4 @@
+---
+space: APM_Config
+name: APM_Config
+description: Space for APM application configurations

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/apm.datamodel.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/apm.datamodel.yaml
@@ -1,18 +1,18 @@
 externalId: APM_SourceData
 name: APM Source data
-version: {{apm_datamodel_version}}
+version: '{{apm_datamodel_version}}'
 space: {{apm_datamodel_space}}
 description: "APM data models for customer source data to be consumed by the APM application."
 views:
   - type: view
     externalId: APM_Activity
     space: {{apm_datamodel_space}}
-    version: {{apm_datamodel_version}}
+    version: '{{apm_datamodel_version}}'
   - type: view
     externalId: APM_Operation
     space: {{apm_datamodel_space}}
-    version: {{apm_datamodel_version}}
+    version: '{{apm_datamodel_version}}'
   - type: view
     externalId: APM_Notification
     space: {{apm_datamodel_space}}
-    version: {{apm_datamodel_version}}
+    version: '{{apm_datamodel_version}}'

--- a/cognite_toolkit/modules/cdf_apm_base/data_models/apm_data_model.space.yaml
+++ b/cognite_toolkit/modules/cdf_apm_base/data_models/apm_data_model.space.yaml
@@ -1,0 +1,4 @@
+---
+space: {{apm_datamodel_space}}
+name: {{apm_datamodel_space}}
+description: Space for APM data model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,37 +70,43 @@ def cognite_client_approval() -> CogniteClient:
     with monkeypatch_cognite_client() as client:
         written_resources: dict[str, Sequence[CogniteResource | dict[str, Any]]] = {}
         deleted_resources: dict[str, list[str | int | dict[str, Any]]] = defaultdict(list)
-        client.iam.groups = create_mock_api(GroupsAPI, GroupList, written_resources, deleted_resources)
-        client.data_sets = create_mock_api(DataSetsAPI, DataSetList, written_resources, deleted_resources)
-        client.time_series = create_mock_api(TimeSeriesAPI, TimeSeriesList, written_resources, deleted_resources)
-        client.raw.databases = create_mock_api(RawDatabasesAPI, DatabaseList, written_resources, deleted_resources)
-        client.raw.tables = create_mock_api(RawTablesAPI, TableList, written_resources, deleted_resources)
+        client.iam.groups = create_mock_api(client, GroupsAPI, GroupList, written_resources, deleted_resources)
+        client.data_sets = create_mock_api(client, DataSetsAPI, DataSetList, written_resources, deleted_resources)
+        client.time_series = create_mock_api(
+            client, TimeSeriesAPI, TimeSeriesList, written_resources, deleted_resources
+        )
+        client.raw.databases = create_mock_api(
+            client, RawDatabasesAPI, DatabaseList, written_resources, deleted_resources
+        )
+        client.raw.tables = create_mock_api(client, RawTablesAPI, TableList, written_resources, deleted_resources)
         client.transformations = create_mock_api(
-            TransformationsAPI, TransformationList, written_resources, deleted_resources
+            client, TransformationsAPI, TransformationList, written_resources, deleted_resources
         )
         client.transformations.schedules = create_mock_api(
-            TransformationSchedulesAPI, TransformationScheduleList, written_resources, deleted_resources
+            client, TransformationSchedulesAPI, TransformationScheduleList, written_resources, deleted_resources
         )
         client.data_modeling.containers = create_mock_api(
-            ContainersAPI, ContainerList, written_resources, deleted_resources, ContainerApplyList
+            client, ContainersAPI, ContainerList, written_resources, deleted_resources, ContainerApplyList
         )
         client.data_modeling.views = create_mock_api(
-            ViewsAPI, ViewList, written_resources, deleted_resources, ViewApplyList
+            client, ViewsAPI, ViewList, written_resources, deleted_resources, ViewApplyList
         )
         client.data_modeling.data_models = create_mock_api(
-            DataModelsAPI, DataModelList, written_resources, deleted_resources, DataModelApplyList
+            client, DataModelsAPI, DataModelList, written_resources, deleted_resources, DataModelApplyList
         )
         client.data_modeling.spaces = create_mock_api(
-            SpacesAPI, SpaceList, written_resources, deleted_resources, SpaceApplyList
+            client, SpacesAPI, SpaceList, written_resources, deleted_resources, SpaceApplyList
         )
-        client.raw.rows = create_mock_api(RawRowsAPI, RowList, written_resources, deleted_resources)
-        client.time_series.data = create_mock_api(DatapointsAPI, DatapointsList, written_resources, deleted_resources)
-        client.files = create_mock_api(FilesAPI, FileMetadataList, written_resources, deleted_resources)
+        client.raw.rows = create_mock_api(client, RawRowsAPI, RowList, written_resources, deleted_resources)
+        client.time_series.data = create_mock_api(
+            client, DatapointsAPI, DatapointsList, written_resources, deleted_resources
+        )
+        client.files = create_mock_api(client, FilesAPI, FileMetadataList, written_resources, deleted_resources)
         client.data_modeling.graphql = create_mock_api(
-            DataModelingGraphQLAPI, DataModelList, written_resources, deleted_resources, DataModelApplyList
+            client, DataModelingGraphQLAPI, DataModelList, written_resources, deleted_resources, DataModelApplyList
         )
         client.data_modeling.instances = create_mock_api(
-            InstancesAPI, NodeList, written_resources, deleted_resources, NodeApplyList
+            client, InstancesAPI, NodeList, written_resources, deleted_resources, NodeApplyList
         )
 
         def dump() -> dict[str, Any]:
@@ -131,6 +137,7 @@ def cognite_client_approval() -> CogniteClient:
 
 
 def create_mock_api(
+    client: CogniteClient,
     api_client: type[APIClient],
     read_list_cls: type[CogniteResourceList],
     written_resources: dict[str, MutableSequence[CogniteResource | dict[str, Any]]],
@@ -139,11 +146,11 @@ def create_mock_api(
 ) -> MagicMock:
     mock = MagicMock(spec=api_client)
     if hasattr(api_client, "list"):
-        mock.list.return_value = read_list_cls([])
+        mock.list.return_value = read_list_cls([], cognite_client=client)
     if hasattr(api_client, "retrieve"):
-        mock.retrieve.return_value = read_list_cls([])
+        mock.retrieve.return_value = read_list_cls([], cognite_client=client)
     if hasattr(api_client, "retrieve_multiple"):
-        mock.retrieve_multiple.return_value = read_list_cls([])
+        mock.retrieve_multiple.return_value = read_list_cls([], cognite_client=client)
 
     resource_cls = read_list_cls._RESOURCE
     write_list_cls = write_list_cls or read_list_cls

--- a/tests/test_approval_modules_snapshots/cdf_apm_base.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_apm_base.yaml
@@ -258,25 +258,25 @@ DataModel:
   externalId: APM_SourceData
   name: APM Source data
   space: APM_SourceData
-  version: 1
+  version: '1'
   views:
   - externalId: APM_Activity
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Operation
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Notification
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
 Space:
-- description: Imported space
+- description: Space for APM application configurations
   name: APM_Config
   space: APM_Config
-- description: Imported space
+- description: Space for APM data model
   name: APM_SourceData
   space: APM_SourceData
 View:
@@ -338,7 +338,7 @@ View:
         externalId: APM_Notification
         space: APM_SourceData
         type: view
-        version: 1
+        version: '1'
       type:
         externalId: APM_Activity.notifications
         space: APM_SourceData
@@ -397,7 +397,7 @@ View:
       description: Nature of the activity, such as corrective or preventive. Use descriptive
         terms over codes for better UI clarity.
   space: APM_SourceData
-  version: 1
+  version: '1'
 - description: Config data for APM applications
   externalId: APM_Config
   name: APM Config
@@ -530,7 +530,7 @@ View:
         Request, or Activity Report. Use descriptive types over codes for clarity
         in the UI.
   space: APM_SourceData
-  version: 1
+  version: '1'
 - description: An operation delineates a distinct maintenance task tailored for a
     specific asset, such as gasket replacement, scaffolding setup, or level measurement.
   externalId: APM_Operation
@@ -615,7 +615,7 @@ View:
       containerPropertyIdentifier: title
       description: Brief title or summary of the specified operation.
   space: APM_SourceData
-  version: 1
+  version: '1'
 deleted:
   Container:
   - externalId: APM_Activity
@@ -638,12 +638,15 @@ deleted:
   - externalId: APM_SourceData
     space: APM_SourceData
     type: datamodel
-    version: 1
+    version: '1'
+  Space:
+  - APM_Config
+  - APM_SourceData
   View:
   - externalId: APM_Activity
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Config
     space: APM_Config
     type: view
@@ -651,8 +654,8 @@ deleted:
   - externalId: APM_Notification
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'
   - externalId: APM_Operation
     space: APM_SourceData
     type: view
-    version: 1
+    version: '1'

--- a/tests/test_approval_modules_snapshots/cdf_apm_simple_data_model.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_apm_simple_data_model.yaml
@@ -327,7 +327,7 @@ DataModel:
     type: view
     version: '1'
 Space:
-- description: Imported space
+- description: Space for APM simple data model
   name: apm_simple
   space: apm_simple
 Transformation:
@@ -1067,6 +1067,8 @@ deleted:
     space: apm_simple
     type: datamodel
     version: '1'
+  Space:
+  - apm_simple
   Transformation:
   - externalId: apm_simple-load-asset-hierarchy
   - externalId: apm_simple-load-asset2children


### PR DESCRIPTION
## Description

- Require all spaces to be explicitly defined
- Add space yaml files for existing data models
- Fix use of integer value in version for data models for apm_base
- Fix container comparison to detect identical containers
- Add support for drop_data in load_datamodel to delete instances (to fix clean command not working)
- Clean up error on resource does not exist when deleting
- Fix group deletion on use of clean command to actually delete
- Add protection on group deletion and skip any groups that service principal belong to

## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
