### PR TITLE
Gtw/fix_oid_dataset

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -34,6 +34,7 @@ Changes are grouped as follows:
 - Data sets are no longer implicitly created when referenced by another resource, instead an error is raised.
 - Require all spaces to be explicitly defined as separate .space.yaml file.
 - Add protection on group deletion and skip any groups that the current service principal belongs to.
+- Support for multiple file resources per yaml config file for files resources.
 
 ### Fixed
 

--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -14,7 +14,7 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [0.1.2] - 2023-11-28
+## [0.1.2] - 2023-11-29
 
 ### Changed
 
@@ -23,7 +23,9 @@ Changes are grouped as follows:
 ### Fixed
 
 - Add space yaml files for existing data models when explicit space definition was introduced.
-- Fix use of integer value in version for data models for .
+- Fix use of integer value in version for data models.
+- Fix wrong reference to `apm_simple` in `examples/cdf_apm_simple_data_model` and `modules/cdf_infield_location`.
+- Examplify use of a single config yaml file for multiple file resources in `examples/cdf_oid_example_data/files/files.yaml`.
 
 ## [0.1.1] - 2023-11-23
 

--- a/cognite_toolkit/cdf_tk/load.py
+++ b/cognite_toolkit/cdf_tk/load.py
@@ -660,34 +660,36 @@ class FileLoader(Loader[str, FileMetadata, FileMetadataList]):
         self.client.files.delete(external_id=ids)
         return len(ids)
 
-    def load_file(self, filepath: Path, ToolGlobals: CDFToolConfig) -> FileMetadata:
-        file = FileMetadata.load(load_yaml_inject_variables(filepath, ToolGlobals.environment_variables()))
-        if not Path(filepath.parent / file.name).exists():
-            raise FileNotFoundError(f"Could not find file {file.name} referenced in filepath {filepath.name}")
-        if isinstance(file.data_set_id, str):
-            # Replace external_id with internal id
-            file.data_set_id = ToolGlobals.verify_dataset(file.data_set_id)
-        return file
+    def load_file(self, filepath: Path, ToolGlobals: CDFToolConfig) -> FileMetadata | FileMetadataList:
+        try:
+            files = FileMetadataList(
+                [FileMetadata.load(load_yaml_inject_variables(filepath, ToolGlobals.environment_variables()))]
+            )
+        except Exception:
+            files = FileMetadataList.load(load_yaml_inject_variables(filepath, ToolGlobals.environment_variables()))
+        for file in files.data:
+            if not Path(filepath.parent / file.name).exists():
+                raise FileNotFoundError(f"Could not find file {file.name} referenced in filepath {filepath.name}")
+            if isinstance(file.data_set_id, str):
+                # Replace external_id with internal id
+                file.data_set_id = ToolGlobals.verify_dataset(file.data_set_id)
+        return files
 
     def create(
         self, items: Sequence[FileMetadata], ToolGlobals: CDFToolConfig, drop: bool, filepath: Path
     ) -> FileMetadataList:
-        if len(items) != 1:
-            raise ValueError("Files must be loaded one at a time.")
-        meta = items[0]
-        datafile = filepath.parent / meta.name
-        try:
-            created = self.client.files.upload(path=datafile, overwrite=drop, **meta.dump(camel_case=False))
-        except CogniteAPIError as e:
-            if e.code == 409:
-                print(f"  [bold yellow]WARNING:[/] File {meta.external_id} already exists, skipping upload.")
-                return FileMetadataList([])
-        except Exception as e:
-            print(f"[bold red]ERROR:[/] Failed to upload file {datafile.name}.\n{e}")
-            ToolGlobals.failed = True
-            return FileMetadataList([])
-        if isinstance(created, FileMetadata):
-            return [created]
+        created = FileMetadataList([])
+        for meta in items:
+            datafile = filepath.parent / meta.name
+            try:
+                created.append(self.client.files.upload(path=datafile, overwrite=drop, **meta.dump(camel_case=False)))
+            except CogniteAPIError as e:
+                if e.code == 409:
+                    print(f"  [bold yellow]WARNING:[/] File {meta.external_id} already exists, skipping upload.")
+            except Exception as e:
+                print(f"[bold red]ERROR:[/] Failed to upload file {datafile.name}.\n{e}")
+                ToolGlobals.failed = True
+                return created
         return created
 
 
@@ -765,8 +767,8 @@ def drop_load_resources(
         print(e)
         ToolGlobals.failed = True
         return
-    print(f"  Deleted {nr_of_deleted} out of {nr_of_items} {loader.api_name} from {len(filepaths)} files.")
-    print(f"  Created {nr_of_created} out of {nr_of_items} {loader.api_name} from {len(filepaths)} files.")
+    print(f"  Deleted {nr_of_deleted} out of {nr_of_items} {loader.api_name} from {len(filepaths)} config files.")
+    print(f"  Created {nr_of_created} out of {nr_of_items} {loader.api_name} from {len(filepaths)} config files.")
 
 
 LOADER_BY_FOLDER_NAME = {loader.folder_name: loader for loader in Loader.__subclasses__()}

--- a/cognite_toolkit/examples/cdf_apm_simple_data_model/default.config.yaml
+++ b/cognite_toolkit/examples/cdf_apm_simple_data_model/default.config.yaml
@@ -1,5 +1,5 @@
 # Only valid for this module, loads template variables from environment
-source_raw_db: apm_simple
+source_raw_db: Valhall_System_23
 datamodel: apm_simple
 space: apm_simple
 datamodel_version: '1'

--- a/cognite_toolkit/examples/cdf_oid_example_data/files/PH-25578-P-4110119-001.pdf.yaml
+++ b/cognite_toolkit/examples/cdf_oid_example_data/files/PH-25578-P-4110119-001.pdf.yaml
@@ -1,4 +1,0 @@
-externalId: {{data_set}}_PH-25578-P-4110119-001.pdf
-dataSetId: {{data_set}}
-name: PH-25578-P-4110119-001.pdf
-source: oid

--- a/cognite_toolkit/examples/cdf_oid_example_data/files/PH-ME-P-0003-001.pdf.yaml
+++ b/cognite_toolkit/examples/cdf_oid_example_data/files/PH-ME-P-0003-001.pdf.yaml
@@ -1,4 +1,0 @@
-externalId: {{data_set}}_PH-ME-P-0003-001.pdf
-dataSetId: {{data_set}}
-name: PH-ME-P-0003-001.pdf
-source: oid

--- a/cognite_toolkit/examples/cdf_oid_example_data/files/files.yaml
+++ b/cognite_toolkit/examples/cdf_oid_example_data/files/files.yaml
@@ -1,0 +1,8 @@
+- externalId: {{data_set}}_PH-ME-P-0003-001.pdf
+  dataSetId: {{data_set}}
+  name: PH-ME-P-0003-001.pdf
+  source: oid
+- externalId: {{data_set}}_PH-25578-P-4110119-001.pdf
+  dataSetId: {{data_set}}
+  name: PH-25578-P-4110119-001.pdf
+  source: oid

--- a/cognite_toolkit/modules/cdf_infield_location/default.config.yaml
+++ b/cognite_toolkit/modules/cdf_infield_location/default.config.yaml
@@ -4,7 +4,7 @@ module_version: '1'
 apm_datamodel_space: 'APM_SourceData'
 apm_app_config_external_id: 'default-infield-config-minimal'
 # RAW database to load workorders and other data from
-raw_db: 'apm_simple'
+raw_db: 'Valhall_System_23'
 # The table name in the raw_db database that has workorder data
 workorder_table_name: 'workorders'
 

--- a/tests/test_approval_modules_snapshots/cdf_apm_simple_data_model.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_apm_simple_data_model.yaml
@@ -350,7 +350,7 @@ Transformation:
   query: "select\n  cast(`externalId` as STRING) as externalId,\n  cast(`externalId`\
     \ as STRING) as name,\n  cast(`description` as STRING) as description,\n  cast(`sourceDb`\
     \ as STRING) as source,\n  cast(`parentExternalId` as STRING) as parentExternalId\n\
-    from\n  `apm_simple`.`assets`;\n"
+    from\n  `Valhall_System_23`.`assets`;\n"
   schedule:
     externalId: apm_simple-load-asset-hierarchy
     interval: 0 * * * *
@@ -386,7 +386,7 @@ Transformation:
   ownerIsCurrentUser: true
   query: "select\n  cast(`externalId` as STRING) as externalId,\n  node_reference('apm_simple',\
     \ `sourceExternalId`) as startNode,\n  node_reference('apm_simple', `targetExternalId`)\
-    \ as endNode\nfrom\n  `apm_simple`.`asset2children`;\n"
+    \ as endNode\nfrom\n  `Valhall_System_23`.`asset2children`;\n"
   schedule:
     externalId: apm_simple-load-asset2children
     interval: 0 * * * *
@@ -427,7 +427,7 @@ Transformation:
     \ as updatedDate,\n  cast(`createdDate` as TIMESTAMP) as createdDate,\n  node_reference('apm_simple',\
     \ `parentExternalId`) as parent,\n  cast(`description` as STRING) as description,\n\
     \  cast(`tag` as STRING) as tag,\n  cast(`areaId` as INT) as areaId,\n  cast(`isActive`\
-    \ as BOOLEAN) as isActive\nfrom\n  `apm_simple`.`assets`;\n"
+    \ as BOOLEAN) as isActive\nfrom\n  `Valhall_System_23`.`assets`;\n"
   schedule:
     externalId: apm_simple-load-assets
     interval: 0 * * * *
@@ -462,7 +462,7 @@ Transformation:
   name: apm_simple-load-timeseries2assets
   ownerIsCurrentUser: true
   query: "select\n  cast(`asset` as STRING) as externalId,\n  array(timeseries) as\
-    \ metrics\nfrom\n  `apm_simple`.`timeseries2assets`;\n"
+    \ metrics\nfrom\n  `Valhall_System_23`.`timeseries2assets`;\n"
   schedule:
     externalId: apm_simple-load-timeseries2assets
     interval: 0 * * * *
@@ -501,7 +501,7 @@ Transformation:
     \  cast(`toBeDone` as BOOLEAN) as toBeDone,\n  cast(`itemInfo` as STRING) as itemInfo,\n\
     \  cast(`itemName` as STRING) as itemName,\n  cast(`title` as STRING) as title,\n\
     \  cast(`criticality` as STRING) as criticality,\n  cast(`method` as STRING) as\
-    \ method,\n  cast(`isCompleted` as BOOLEAN) as isCompleted\nfrom\n  `apm_simple`.`workitems`;\n"
+    \ method,\n  cast(`isCompleted` as BOOLEAN) as isCompleted\nfrom\n  `Valhall_System_23`.`workitems`;\n"
   schedule:
     externalId: apm_simple-load-workitems
     interval: 0 * * * *
@@ -543,7 +543,7 @@ Transformation:
     tutorial_apm\",\"sourceLevel2\":\"workitem2assets\"} */ select\n  cast(`externalId`\
     \ as STRING) as externalId,\n  node_reference('apm_simple', `sourceExternalId`)\
     \ as startNode,\n  node_reference('apm_simple', `targetExternalId`) as endNode\n\
-    from\n  `apm_simple`.`workitem2assets`;\n"
+    from\n  `Valhall_System_23`.`workitem2assets`;\n"
   schedule:
     externalId: apm_simple-load-workitems2assets
     interval: 0 * * * *
@@ -585,7 +585,7 @@ Transformation:
     tutorial_apm\",\"sourceLevel2\":\"workorder2items\"} */ select\n  cast(`externalId`\
     \ as STRING) as externalId,\n  node_reference('apm_simple', `sourceExternalId`)\
     \ as startNode,\n  node_reference('apm_simple', `targetExternalId`) as endNode\n\
-    from\n  `apm_simple`.`workorder2items`;\n"
+    from\n  `Valhall_System_23`.`workorder2items`;\n"
   schedule:
     externalId: apm_simple-load-workitems2workorders
     interval: 0 * * * *
@@ -631,7 +631,7 @@ Transformation:
     \ as isCancelled, \ncast(`isActive` as BOOLEAN) as isActive, \ncast(`priorityDescription`\
     \ as STRING) as priorityDescription, \ncast(`dueDate` as TIMESTAMP) as dueDate,\
     \ \ncast(`createdDate` as TIMESTAMP) as createdDate, \ncast(`programNumber` as\
-    \ STRING) as programNumber \nfrom `apm_simple`.`workorders`;\n"
+    \ STRING) as programNumber \nfrom `Valhall_System_23`.`workorders`;\n"
   schedule:
     externalId: apm_simple-load-workorders
     interval: 0 * * * *
@@ -667,7 +667,7 @@ Transformation:
   ownerIsCurrentUser: true
   query: "select\n  cast(`externalId` as STRING) as externalId,\n  node_reference('apm_simple',\
     \ `sourceExternalId`) as startNode,\n  node_reference('apm_simple', `targetExternalId`)\
-    \ as endNode\nfrom\n  `apm_simple`.`workorder2assets`;\n"
+    \ as endNode\nfrom\n  `Valhall_System_23`.`workorder2assets`;\n"
   schedule:
     externalId: apm_simple-load-workorders2assets
     interval: 0 * * * *

--- a/tests/test_approval_modules_snapshots/cdf_infield_location.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_infield_location.yaml
@@ -476,7 +476,7 @@ Transformation:
     \    cast(`endTime` as TIMESTAMP) as endTime,*/\n    cast('2023-11-06T09:00:00'\
     \ as TIMESTAMP) as startTime,\n    cast('2023-11-10T09:00:00' as TIMESTAMP) as\
     \ endTime,\n    cast(`title` as STRING) as title,\n    'WMT:VAL' as rootLocation,\n\
-    \    'workmate' as source\n  from\n    `apm_simple`.`workorders`;\n"
+    \    'workmate' as source\n  from\n    `Valhall_System_23`.`workorders`;\n"
   schedule:
     externalId: sync_workorders_to_apm_activities
     interval: 0 * * * *


### PR DESCRIPTION
## Description

- Fix wrong reference to apm_simple RAW db after renaming of default db name for cdf_oid_example_data.
- Add support for multiple file resources defined in a single yaml config file.

## Checklist:
- [x] Tests added/updated.
- [ ] Documentation updated.
- [x] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [x] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
