### PR TITLE
Added support for nested metadata in datasets

### DIFF
--- a/cognite_toolkit/cdf_tk/load.py
+++ b/cognite_toolkit/cdf_tk/load.py
@@ -433,7 +433,7 @@ class DataSetsLoader(Loader[str, DataSet, DataSetList]):
         for data_set in data_sets:
             if data_set.get("metadata"):
                 for key, value in data_set["metadata"].items():
-                    data_set["metadata"][key] = json.dumps(value)
+                    data_set["metadata"][key] = json.dumps(value) if isinstance(value, dict) else value
         return DataSetList.load(data_sets)
 
     def create(

--- a/cognite_toolkit/cdf_tk/load.py
+++ b/cognite_toolkit/cdf_tk/load.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import io
 import itertools
+import json
 import re
 from abc import ABC, abstractmethod
 from collections import Counter, defaultdict
@@ -425,6 +426,15 @@ class DataSetsLoader(Loader[str, DataSet, DataSetList]):
         local.created_time = remote.created_time
         local.last_updated_time = remote.last_updated_time
         return local
+
+    def load_resource(self, filepath: Path, ToolGlobals: CDFToolConfig, dry_run: bool) -> DataSetList:
+        resource = load_yaml_inject_variables(filepath, {})
+        data_sets = list(resource) if isinstance(resource, dict) else resource
+        for data_set in data_sets:
+            if data_set.get("metadata"):
+                for key, value in data_set["metadata"].items():
+                    data_set["metadata"][key] = json.dumps(value)
+        return DataSetList.load(data_sets)
 
     def create(
         self, items: Sequence[T_Resource], ToolGlobals: CDFToolConfig, drop: bool, filepath: Path


### PR DESCRIPTION
## Description

Dataset metadata may look like this:
```
- externalId: 'ds_infield_default_app_data'
  name: infield:default:app_data
  description: This dataset is for writing data from Infield for the location default.

  metadata: 
    consoleSource:
      names:
        - '{{source_name}}'
    rawTables:
      - databaseName: 'asset-{{location_name}}-{{source_name}}'
        tableName: 'assets'
    transformations:
      - externalId: 'tr_asset_{{location_name}}_{{source_name}}_asset_hierarchy'
        type: 'jetfire'
```

This PR flattens the metadata values with json since the API expects a dict(str, str)





## Checklist:
- [ ] Tests added/updated.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
