### PR TITLE
Build checks

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -19,6 +19,8 @@ Changes are grouped as follows:
 ### Added
 - Warnings if a configuration file is using `snake_case` when then resource type is expecting `camelCase`.
 - Added support for validation of `space` for data models.
+- Check for whether template variables `<change_me>` are present in the config files.
+- Check for whether data set id is present in the config files.
 ### Removed
 - In the `deploy` command `drop_data` option has been removed. To drop data, use the `clean` command instead.
 ### Changed

--- a/cognite_toolkit/cdf_tk/templates.py
+++ b/cognite_toolkit/cdf_tk/templates.py
@@ -16,7 +16,7 @@ from rich import print
 from ruamel.yaml import YAML, CommentedMap
 
 from cognite_toolkit.cdf_tk.load import LOADER_BY_FOLDER_NAME
-from cognite_toolkit.cdf_tk.utils import validate_case_raw, validate_config_yaml
+from cognite_toolkit.cdf_tk.utils import validate_case_raw, validate_config_yaml, validate_data_set_is_set
 
 # This is the default config located locally in each module.
 DEFAULT_CONFIG_FILE = "default.config.yaml"
@@ -800,12 +800,17 @@ def validate(content: str, destination: Path, source_path: Path) -> None:
             loader = loader[0]
         else:
             loader = next((loader for loader in loader if re.match(loader.filename_pattern, destination.stem)), None)
+
         if loader:
             load_warnings = validate_case_raw(
                 parsed, loader.resource_cls, destination, identifier_key=loader.identifier_key
             )
             if load_warnings:
                 print(f"  [bold yellow]WARNING:[/] Found potential snake_case issues: {load_warnings!s}")
+
+            data_set_warnings = validate_data_set_is_set(parsed, loader.resource_cls, destination)
+            if data_set_warnings:
+                print(f"  [bold yellow]WARNING:[/] Found missing data_sets: {data_set_warnings!s}")
 
 
 if __name__ == "__main__":

--- a/cognite_toolkit/cdf_tk/templates.py
+++ b/cognite_toolkit/cdf_tk/templates.py
@@ -16,7 +16,7 @@ from rich import print
 from ruamel.yaml import YAML, CommentedMap
 
 from cognite_toolkit.cdf_tk.load import LOADER_BY_FOLDER_NAME
-from cognite_toolkit.cdf_tk.utils import LoadWarning, validate_case_raw
+from cognite_toolkit.cdf_tk.utils import validate_case_raw, validate_config_yaml
 
 # This is the default config located locally in each module.
 DEFAULT_CONFIG_FILE = "default.config.yaml"
@@ -489,20 +489,12 @@ def build_config(
     selected_modules = get_selected_modules(source_module_dir, environment_file, build_env, verbose)
 
     config = read_yaml_file(config_file)
+    warnings = validate_config_yaml(config, config_file)
+    if warnings:
+        print("  [bold yellow]WARNING:[/] Found the following warnings in config.yaml:")
+        for warning in warnings:
+            print(f"    {warning}")
     process_config_files(source_module_dir, selected_modules, build_dir, config, build_env, verbose)
-
-
-def generate_warnings_report(load_warnings: list[LoadWarning], indent: int = 0) -> str:
-    report = [""]
-    for (file, identifier, id_name), file_warnings in itertools.groupby(
-        sorted(load_warnings), key=lambda w: (w.filepath, w.id_value, w.id_name)
-    ):
-        report.append(f"{'    '*indent}In File {str(file)!r}")
-        report.append(f"{'    '*indent}In entry {id_name}={identifier!r}")
-        for warning in file_warnings:
-            report.append(f"{'    '*(indent+1)}{warning!s}")
-
-    return "\n".join(report)
 
 
 def generate_config(
@@ -813,7 +805,7 @@ def validate(content: str, destination: Path, source_path: Path) -> None:
                 parsed, loader.resource_cls, destination, identifier_key=loader.identifier_key
             )
             if load_warnings:
-                print(f"  [bold yellow]WARNING:[/]{generate_warnings_report(load_warnings, indent=1)}")
+                print(f"  [bold yellow]WARNING:[/] Found potential snake_case issues: {load_warnings!s}")
 
 
 if __name__ == "__main__":

--- a/cognite_toolkit/cdf_tk/utils.py
+++ b/cognite_toolkit/cdf_tk/utils.py
@@ -16,15 +16,18 @@ from __future__ import annotations
 import abc
 import collections
 import inspect
+import itertools
 import json
 import logging
 import os
+import re
 import typing
-from collections.abc import Sequence
+from collections import UserList
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 from functools import total_ordering
 from pathlib import Path
-from typing import Any, get_origin
+from typing import Any, ClassVar, Generic, TypeVar, get_origin
 
 import yaml
 from cognite.client import ClientConfig, CogniteClient
@@ -388,6 +391,7 @@ def load_yaml_inject_variables(filepath: Path, variables: dict[str, str]) -> dic
 
 @dataclass(frozen=True)
 class LoadWarning:
+    _type: ClassVar[str]
     filepath: Path
     id_value: str
     id_name: str
@@ -395,12 +399,12 @@ class LoadWarning:
 
 @total_ordering
 @dataclass(frozen=True)
-class CaseWarning(LoadWarning):
+class SnakeCaseWarning(LoadWarning):
     actual: str
     expected: str
 
-    def __lt__(self, other: CaseWarning) -> bool:
-        if not isinstance(other, CaseWarning):
+    def __lt__(self, other: SnakeCaseWarning) -> bool:
+        if not isinstance(other, SnakeCaseWarning):
             return NotImplemented
         return (self.filepath, self.id_value, self.expected, self.actual) < (
             other.filepath,
@@ -409,8 +413,8 @@ class CaseWarning(LoadWarning):
             other.actual,
         )
 
-    def __eq__(self, other: CaseWarning) -> bool:
-        if not isinstance(other, CaseWarning):
+    def __eq__(self, other: SnakeCaseWarning) -> bool:
+        if not isinstance(other, SnakeCaseWarning):
             return NotImplemented
         return (self.filepath, self.id_value, self.expected, self.actual) == (
             other.filepath,
@@ -423,12 +427,65 @@ class CaseWarning(LoadWarning):
         return f"CaseWarning: Got {self.actual!r}. Did you mean {self.expected!r}?"
 
 
+@total_ordering
+@dataclass(frozen=True)
+class TemplateVariableWarning(LoadWarning):
+    path: str
+
+    def __lt__(self, other: TemplateVariableWarning) -> bool:
+        if not isinstance(other, TemplateVariableWarning):
+            return NotImplemented
+        return (self.id_name, self.id_value, self.path) < (other.id_name, other.id_value, other.path)
+
+    def __eq__(self, other: TemplateVariableWarning) -> bool:
+        if not isinstance(other, TemplateVariableWarning):
+            return NotImplemented
+        return (self.id_name, self.id_value, self.path) == (other.id_name, other.id_value, other.path)
+
+    def __str__(self):
+        return f"{type(self).__name__}: Variable {self.id_name!r} has value {self.id_value!r} in file: {self.filepath.name}. Did you forget to change it?"
+
+
+T_Warning = TypeVar("T_Warning", bound=LoadWarning)
+
+
+class Warnings(UserList, Generic[T_Warning]):
+    def __init__(self, collection: Collection[T_Warning] | None = None):
+        super().__init__(collection or [])
+
+
+class SnakeCaseWarningList(Warnings[SnakeCaseWarning]):
+    def __str__(self) -> str:
+        output = [""]
+        for (file, identifier, id_name), file_warnings in itertools.groupby(
+            sorted(self), key=lambda w: (w.filepath, w.id_value, w.id_name)
+        ):
+            output.append(f"    In File {str(file)!r}")
+            output.append(f"    In entry {id_name}={identifier!r}")
+            for warning in file_warnings:
+                output.append(f"{'    ' * 2}{warning!s}")
+
+        return "\n".join(output)
+
+
+class TemplateVariableWarningList(Warnings[TemplateVariableWarning]):
+    def __str__(self):
+        output = [""]
+        for path, module_warnings in itertools.groupby(sorted(self), key=lambda w: w.path):
+            if path:
+                output.append(f"    In Section {str(path)!r}")
+            for warning in module_warnings:
+                output.append(f"{'    ' * 2}{warning!s}")
+
+        return "\n".join(output)
+
+
 def validate_case_raw(
     raw: dict[str, Any] | list[dict[str, Any]],
     resource_cls: type[CogniteObject],
     filepath: Path,
     identifier_key: str = "externalId",
-) -> list[CaseWarning]:
+) -> SnakeCaseWarningList:
     """Checks whether camel casing the raw data would match a parameter in the resource class.
 
     Args:
@@ -452,8 +509,8 @@ def _validate_case_raw(
     filepath: Path,
     identifier_key: str = "externalId",
     identifier_value: str = "",
-) -> list[CaseWarning]:
-    warnings = []
+) -> SnakeCaseWarningList:
+    warnings = SnakeCaseWarningList()
     if isinstance(raw, list):
         for item in raw:
             warnings.extend(_validate_case_raw(item, resource_cls, filepath, identifier_key))
@@ -486,7 +543,7 @@ def _validate_case_raw(
 
     for key in snake_cased:
         if (camel_key := to_camel_case(key)) in expected:
-            warnings.append(CaseWarning(filepath, identifier_value, identifier_key, str(key), str(camel_key)))
+            warnings.append(SnakeCaseWarning(filepath, identifier_value, identifier_key, str(key), str(camel_key)))
 
     try:
         type_hints_by_name = _TypeHints.get_type_hints_by_name(signature, resource_cls)
@@ -517,4 +574,27 @@ def _validate_case_raw(
                         _validate_case_raw(sub_value, container_value, filepath, identifier_key, identifier_value)
                     )
 
+    return warnings
+
+
+def validate_config_yaml(config: dict[str, Any], filepath: Path, path: str = "") -> TemplateVariableWarningList:
+    """Checks whether the config file has any issues.
+
+    Currently, this checks for:
+        * Non-replaced template variables, such as <change_me>.
+
+    Args:
+        config: The config to check.
+        filepath: The filepath of the config.yaml.
+        path: The path in the config.yaml. This is used recursively by this function.
+    """
+    warnings = TemplateVariableWarningList()
+    pattern = re.compile(r"<.*?>")
+    for key, value in config.items():
+        if isinstance(value, str) and pattern.match(value):
+            warnings.append(TemplateVariableWarning(filepath, value, key, path))
+        elif isinstance(value, dict):
+            if path:
+                path += "."
+            warnings.extend(validate_config_yaml(value, filepath, f"{path}{key}"))
     return warnings

--- a/cognite_toolkit/cdf_tk/utils.py
+++ b/cognite_toolkit/cdf_tk/utils.py
@@ -449,6 +449,8 @@ class TemplateVariableWarning(LoadWarning):
 @total_ordering
 @dataclass(frozen=True)
 class DataSetMissingWarning(LoadWarning):
+    resource_name: str
+
     def __lt__(self, other: DataSetMissingWarning) -> bool:
         if not isinstance(other, DataSetMissingWarning):
             return NotImplemented
@@ -460,7 +462,7 @@ class DataSetMissingWarning(LoadWarning):
         return (self.id_name, self.id_value, self.filepath) == (other.id_name, other.id_value, other.filepath)
 
     def __str__(self):
-        return f"{type(self).__name__}: {self.resource_name} has a data set id and it is recommended that you have it. This is missing in {self.filepath.name}. Did you forget to add it?"
+        return f"{type(self).__name__}: It is recommended that you set dataSetExternalId for {self.resource_name}. This is missing in {self.filepath.name}. Did you forget to add it?"
 
 
 T_Warning = TypeVar("T_Warning", bound=LoadWarning)
@@ -648,5 +650,5 @@ def validate_data_set_is_set(
         return warnings
 
     value = raw.get(identifier_key, raw.get(to_snake_case(identifier_key), f"No identifier {identifier_key}"))
-    warnings.append(DataSetMissingWarning(filepath, value, identifier_key))
+    warnings.append(DataSetMissingWarning(filepath, value, identifier_key, resource_cls.__name__))
     return warnings

--- a/tests/test_cdf_tk/data/config.yaml
+++ b/tests/test_cdf_tk/data/config.yaml
@@ -1,0 +1,14 @@
+cognite_modules:
+  a_module:
+    readwrite_source_id: <change_me>
+    readonly_source_id: <change_me>
+  another_module:
+    default_location: oid
+    source_asset: workmate
+    source_workorder: workmate
+    source_files: fileshare
+    source_timeseries: pi
+  top_variable: <top_variable>
+  parent_module:
+    child_module:
+      child_variable: <change_me>

--- a/tests/test_cdf_tk/project_configs/cognite_modules/a_module/auth/readonly.all.group.yaml
+++ b/tests/test_cdf_tk/project_configs/cognite_modules/a_module/auth/readonly.all.group.yaml
@@ -1,0 +1,11 @@
+name: 'gp_cicd_all_read_only'
+sourceId: '{{readonly_source_id}}'
+metadata:
+  origin: 'cdf-project-templates'
+capabilities:
+  - projectsAcl:
+      actions:
+        - LIST
+        - READ
+      scope:
+        all: {}

--- a/tests/test_cdf_tk/test_templates.py
+++ b/tests/test_cdf_tk/test_templates.py
@@ -10,7 +10,6 @@ from cognite_toolkit.cdf_tk.templates import (
     COGNITE_MODULES,
     create_local_config,
     generate_config,
-    process_config_files,
     split_config,
 )
 
@@ -92,24 +91,3 @@ def test_create_local_config(my_config: dict[str, Any]):
     local_config = create_local_config(configs, Path("parent/child/auth/"))
 
     assert dict(local_config.items()) == {"top_variable": "my_top_variable", "child_variable": "my_child_variable"}
-
-
-class FakePrintLogger:
-    def __init__(self):
-        self.messages = []
-
-    def __call__(self, *args, **kwargs):
-        self.messages.append(args)
-
-
-def test_warning_on_change_me(tmp_path, monkeypatch: pytest.MonkeyPatch):
-    logger = FakePrintLogger()
-    monkeypatch.setattr("cognite_toolkit.cdf_tk.templates.print", logger)
-
-    process_config_files(
-        BUILD_CONFIG, ["a_module"], tmp_path / "build", yaml.safe_load((DATA / "config.yaml").read_text())
-    )
-
-    messages = logger.messages
-    warning = "WARNING: Template variable <change_me> in file: . Did you forget to change it?" in messages
-    assert warning, "No warning was printed"

--- a/tests/test_cdf_tk/test_templates.py
+++ b/tests/test_cdf_tk/test_templates.py
@@ -6,9 +6,16 @@ from typing import Any
 import pytest
 import yaml
 
-from cognite_toolkit.cdf_tk.templates import COGNITE_MODULES, create_local_config, generate_config, split_config
+from cognite_toolkit.cdf_tk.templates import (
+    COGNITE_MODULES,
+    create_local_config,
+    generate_config,
+    process_config_files,
+    split_config,
+)
 
 BUILD_CONFIG = Path(__file__).parent / "project_configs"
+DATA = Path(__file__).parent / "data"
 
 
 def generate_config_test_cases():
@@ -85,3 +92,24 @@ def test_create_local_config(my_config: dict[str, Any]):
     local_config = create_local_config(configs, Path("parent/child/auth/"))
 
     assert dict(local_config.items()) == {"top_variable": "my_top_variable", "child_variable": "my_child_variable"}
+
+
+class FakePrintLogger:
+    def __init__(self):
+        self.messages = []
+
+    def __call__(self, *args, **kwargs):
+        self.messages.append(args)
+
+
+def test_warning_on_change_me(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    logger = FakePrintLogger()
+    monkeypatch.setattr("cognite_toolkit.cdf_tk.templates.print", logger)
+
+    process_config_files(
+        BUILD_CONFIG, ["a_module"], tmp_path / "build", yaml.safe_load((DATA / "config.yaml").read_text())
+    )
+
+    messages = logger.messages
+    warning = "WARNING: Template variable <change_me> in file: . Did you forget to change it?" in messages
+    assert warning, "No warning was printed"

--- a/tests/test_cdf_tk/test_utils.py
+++ b/tests/test_cdf_tk/test_utils.py
@@ -147,4 +147,6 @@ def test_validate_data_set_is_set():
         {"externalId": "myTimeSeries", "name": "My Time Series"}, TimeSeries, Path("timeseries.yaml")
     )
 
-    assert sorted(warnings) == sorted([DataSetMissingWarning(Path("timeseries.yaml"), "myTimeSeries", "externalId")])
+    assert sorted(warnings) == sorted(
+        [DataSetMissingWarning(Path("timeseries.yaml"), "myTimeSeries", "externalId", "TimeSeries")]
+    )

--- a/tests/test_cdf_tk/test_utils.py
+++ b/tests/test_cdf_tk/test_utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -16,7 +17,14 @@ from cognite.client.data_classes.iam import ProjectSpec
 from cognite.client.exceptions import CogniteAuthError
 from cognite.client.testing import CogniteClientMock
 
-from cognite_toolkit.cdf_tk.utils import CaseWarning, CDFToolConfig, load_yaml_inject_variables, validate_case_raw
+from cognite_toolkit.cdf_tk.utils import (
+    CDFToolConfig,
+    SnakeCaseWarning,
+    TemplateVariableWarning,
+    load_yaml_inject_variables,
+    validate_case_raw,
+    validate_config_yaml,
+)
 
 THIS_FOLDER = Path(__file__).resolve().parent
 
@@ -87,8 +95,8 @@ def test_validate_raw() -> None:
     assert len(warnings) == 2
     assert sorted(warnings) == sorted(
         [
-            CaseWarning(raw_file, "wrong_case", "externalId", "is_string", "isString"),
-            CaseWarning(raw_file, "wrong_case", "externalId", "is_step", "isStep"),
+            SnakeCaseWarning(raw_file, "wrong_case", "externalId", "is_string", "isString"),
+            SnakeCaseWarning(raw_file, "wrong_case", "externalId", "is_step", "isStep"),
         ]
     )
 
@@ -99,5 +107,34 @@ def test_validate_raw_nested() -> None:
 
     assert len(warnings) == 1
     assert warnings == [
-        CaseWarning(raw_file, "WorkItem", "externalId", "container_property_identifier", "containerPropertyIdentifier")
+        SnakeCaseWarning(
+            raw_file, "WorkItem", "externalId", "container_property_identifier", "containerPropertyIdentifier"
+        )
     ]
+
+
+@pytest.mark.parametrize(
+    "config_yaml, expected_warnings",
+    [
+        pytest.param(
+            {"sourceId": "<change_me>"},
+            [TemplateVariableWarning(Path("config.yaml"), "<change_me>", "sourceId", "")],
+            id="Single warning",
+        ),
+        pytest.param(
+            {"a_module": {"sourceId": "<change_me>"}},
+            [TemplateVariableWarning(Path("config.yaml"), "<change_me>", "sourceId", "a_module")],
+            id="Nested warning",
+        ),
+        pytest.param(
+            {"a_super_module": {"a_module": {"sourceId": "<change_me>"}}},
+            [TemplateVariableWarning(Path("config.yaml"), "<change_me>", "sourceId", "a_super_module.a_module")],
+            id="Deep nested warning",
+        ),
+        pytest.param({"a_module": {"sourceId": "123"}}, [], id="No warning"),
+    ],
+)
+def test_validate_config_yaml(config_yaml: dict[str, Any], expected_warnings: list[TemplateVariableWarning]) -> None:
+    warnings = validate_config_yaml(config_yaml, Path("config.yaml"))
+
+    assert sorted(warnings) == sorted(expected_warnings)

--- a/tests/test_cdf_tk/test_utils.py
+++ b/tests/test_cdf_tk/test_utils.py
@@ -19,11 +19,13 @@ from cognite.client.testing import CogniteClientMock
 
 from cognite_toolkit.cdf_tk.utils import (
     CDFToolConfig,
+    DataSetMissingWarning,
     SnakeCaseWarning,
     TemplateVariableWarning,
     load_yaml_inject_variables,
     validate_case_raw,
     validate_config_yaml,
+    validate_data_set_is_set,
 )
 
 THIS_FOLDER = Path(__file__).resolve().parent
@@ -138,3 +140,11 @@ def test_validate_config_yaml(config_yaml: dict[str, Any], expected_warnings: li
     warnings = validate_config_yaml(config_yaml, Path("config.yaml"))
 
     assert sorted(warnings) == sorted(expected_warnings)
+
+
+def test_validate_data_set_is_set():
+    warnings = validate_data_set_is_set(
+        {"externalId": "myTimeSeries", "name": "My Time Series"}, TimeSeries, Path("timeseries.yaml")
+    )
+
+    assert sorted(warnings) == sorted([DataSetMissingWarning(Path("timeseries.yaml"), "myTimeSeries", "externalId")])


### PR DESCRIPTION
## Description
Check for `<change_me>`
```
  WARNING: Found the following warnings in config.yaml:
    TemplateVariableWarning: Variable 'readwrite_source_id' has value '<change_me>' in file: config.yaml. Did you forget to change it?
    TemplateVariableWarning: Variable 'readonly_source_id' has value '<change_me>' in file: config.yaml. Did you forget to change it?
    TemplateVariableWarning: Variable 'applicationsconfiguration_source_id' has value '<change_me>' in file: config.yaml. Did you forget to change it?
    TemplateVariableWarning: Variable 'infield_default_location_checklist_admin_users_source_id' has value '<change_me>' in file: config.yaml. Did you forget to change it?
    TemplateVariableWarning: Variable 'infield_default_location_normal_users_source_id' has value '<change_me>' in file: config.yaml. Did you forget to change it?
    TemplateVariableWarning: Variable 'infield_default_location_template_admin_users_source_id' has value '<change_me>' in file: config.yaml. Did you forget to change it?
    TemplateVariableWarning: Variable 'infield_default_location_viewer_users_source_id' has value '<change_me>' in file: config.yaml. Did you forget to change it?
```

Check for data set
```
  WARNING: Found missing data_sets:
    In file 'build\\transformations\\3.tr_asset_oid_workmate_infield_sync_assets_from_hierarchy_to_apm.yaml'
        DataSetMissingWarning: It is recommended that you set dataSetExternalId for Transformation. This is missing in 3.tr_asset_oid_workmate_infield_sync_assets_from_hierarchy_to_apm.yaml. Did you forget to add it?
  WARNING: Found missing data_sets: 
    In file 'build\\transformations\\4.tr_workorder_oid_workmate_infield_sync_workorders_to_apm_activities.yaml'
        DataSetMissingWarning: It is recommended that you set dataSetExternalId for Transformation. This is missing in 4.tr_workorder_oid_workmate_infield_sync_workorders_to_apm_activities.yaml. Did you forget to add it?
```

## Checklist:
- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
