### PR TITLE
[CDF-20466] Dry run Test to Check that Verify_Dataset is not called with --dry-run flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -461,7 +461,7 @@ class APIResource:
 
     api_name: str
     resource_cls: type[CogniteResource]
-    list_cls: type[CogniteResourceList]
+    list_cls: type[CogniteResourceList] | type[list]
     methods: dict[Literal["create", "delete", "retrieve"], list[Method]]
 
     _write_cls: type[CogniteResource] | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,9 @@ from cognite.client.data_classes import (
     DatapointsList,
     DataSet,
     DataSetList,
+    ExtractionPipeline,
+    ExtractionPipelineConfig,
+    ExtractionPipelineList,
     FileMetadata,
     FileMetadataList,
     Group,
@@ -569,6 +572,32 @@ _API_RESOURCES = [
                 Method(api_class_method="list", mock_name="return_values"),
                 Method(api_class_method="retrieve", mock_name="return_value"),
                 Method(api_class_method="retrieve_multiple", mock_name="return_values"),
+            ],
+        },
+    ),
+    APIResource(
+        api_name="extraction_pipelines",
+        resource_cls=ExtractionPipeline,
+        list_cls=ExtractionPipelineList,
+        methods={
+            "create": [Method(api_class_method="create", mock_name="create")],
+            "delete": [Method(api_class_method="delete", mock_name="delete_id_external_id")],
+            "retrieve": [
+                Method(api_class_method="list", mock_name="return_values"),
+                Method(api_class_method="retrieve", mock_name="return_value"),
+                Method(api_class_method="retrieve_multiple", mock_name="return_values"),
+            ],
+        },
+    ),
+    APIResource(
+        api_name="extraction_pipelines.config",
+        resource_cls=ExtractionPipelineConfig,
+        list_cls=ExtractionPipelineConfig,
+        methods={
+            "create": [Method(api_class_method="create", mock_name="create")],
+            "retrieve": [
+                Method(api_class_method="list", mock_name="return_values"),
+                Method(api_class_method="retrieve", mock_name="return_value"),
             ],
         },
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -303,12 +303,7 @@ class ApprovalCogniteClient:
                 }
             )
 
-        def apply_dml(*args, **kwargs):
-            data = dict(kwargs)
-            data["args"] = list(args)
-            created_resources[resource_cls.__name__].append(data)
-
-        available_create_methods = {fn.__name__: fn for fn in [create, insert_dataframe, upload, apply_dml]}
+        available_create_methods = {fn.__name__: fn for fn in [create, insert_dataframe, upload]}
         if mock_method not in available_create_methods:
             raise ValueError(
                 f"Invalid mock create method {mock_method} for resource {resource_cls.__name__}. Supported {available_create_methods.keys()}"

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -213,7 +213,6 @@ def test_deploy_dry_run_module_approval(
     assert (
         cdf_tool_config.verify_extraction_pipeline.call_count == 0
     ), "Extraction pipelines should not be checked in dry run"
-    assert cdf_tool_config.verify_capabilities.call_count == 0, "Capabilities should not be checked in dry run"
 
 
 @pytest.mark.parametrize("module_path", list(find_all_modules()))

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -166,6 +166,7 @@ def test_deploy_module_approval(
         dry_run=False,
         include=[],
     )
+
     not_mocked = cognite_client_approval.not_mocked_calls()
     assert not not_mocked, (
         f"The following APIs have been called without being mocked: {not_mocked}, "

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -202,6 +202,12 @@ def test_deploy_dry_run_module_approval(
         include=[],
     )
 
+    assert not (
+        calls := cognite_client_approval.create_calls()
+    ), f"No resources should be created in dry run: got these calls: {calls}"
+    assert not (
+        calls := cognite_client_approval.delete_calls()
+    ), f"No resources should be deleted in dry run: got these calls: {calls}"
     assert cdf_tool_config.verify_dataset.call_count == 0, "Dataset should not be checked in dry run"
     assert cdf_tool_config.verify_spaces.call_count == 0, "Spaces should not be checked in dry run"
     assert (

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -15,12 +15,12 @@ from unittest.mock import MagicMock
 
 import pytest
 import typer
-from cognite.client import CogniteClient
 from pytest import MonkeyPatch
 
 from cognite_toolkit.cdf import Common, build, clean, deploy, main_init
 from cognite_toolkit.cdf_tk.templates import COGNITE_MODULES, iterate_modules, read_yaml_file, read_yaml_files
 from cognite_toolkit.cdf_tk.utils import CDFToolConfig
+from tests.conftest import ApprovalCogniteClient
 
 REPO_ROOT = Path(__file__).parent.parent
 
@@ -67,7 +67,7 @@ def local_tmp_project_path(local_tmp_path: Path):
 
 
 @pytest.fixture
-def cdf_tool_config(cognite_client_approval: CogniteClient, monkeypatch: MonkeyPatch) -> CDFToolConfig:
+def cdf_tool_config(cognite_client_approval: ApprovalCogniteClient, monkeypatch: MonkeyPatch) -> CDFToolConfig:
     monkeypatch.setenv("CDF_PROJECT", "pytest-project")
     monkeypatch.setenv("IDP_TOKEN_URL", "dummy")
     monkeypatch.setenv("IDP_CLIENT_ID", "dummy")
@@ -76,8 +76,8 @@ def cdf_tool_config(cognite_client_approval: CogniteClient, monkeypatch: MonkeyP
     with chdir(REPO_ROOT):
         # Build must always be executed from root of the project
         cdf_tool = MagicMock(spec=CDFToolConfig)
-        cdf_tool.verify_client.return_value = cognite_client_approval
-        cdf_tool.verify_capabilities.return_value = cognite_client_approval
+        cdf_tool.verify_client.return_value = cognite_client_approval.mock_client
+        cdf_tool.verify_capabilities.return_value = cognite_client_approval.mock_client
         cdf_tool.failed = False
 
         cdf_tool.verify_dataset.return_value = 42
@@ -141,7 +141,7 @@ def test_deploy_module_approval(
     local_tmp_path: Path,
     local_tmp_project_path: Path,
     monkeypatch: MonkeyPatch,
-    cognite_client_approval: CogniteClient,
+    cognite_client_approval: ApprovalCogniteClient,
     cdf_tool_config: CDFToolConfig,
     typer_context: typer.Context,
     init_project: None,
@@ -177,7 +177,7 @@ def test_deploy_dry_run_module_approval(
     local_tmp_path: Path,
     local_tmp_project_path: Path,
     monkeypatch: MonkeyPatch,
-    cognite_client_approval: CogniteClient,
+    cognite_client_approval: ApprovalCogniteClient,
     cdf_tool_config: CDFToolConfig,
     typer_context: typer.Context,
     init_project: None,
@@ -216,7 +216,7 @@ def test_clean_module_approval(
     local_tmp_path: Path,
     local_tmp_project_path: Path,
     monkeypatch: MonkeyPatch,
-    cognite_client_approval: CogniteClient,
+    cognite_client_approval: ApprovalCogniteClient,
     cdf_tool_config: CDFToolConfig,
     typer_context: typer.Context,
     data_regression,

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -170,7 +170,7 @@ def test_deploy_module_approval(
     not_mocked = cognite_client_approval.not_mocked_calls()
     assert not not_mocked, (
         f"The following APIs have been called without being mocked: {not_mocked}, "
-        "Please update the _API_RESOURCES in tests/conftest.py"
+        "Please update the list _API_RESOURCES in tests/conftest.py"
     )
 
     dump = cognite_client_approval.dump()
@@ -261,5 +261,10 @@ def test_clean_module_approval(
         include=[],
     )
 
+    not_mocked = cognite_client_approval.not_mocked_calls()
+    assert not not_mocked, (
+        f"The following APIs have been called without being mocked: {not_mocked}, "
+        "Please update the list _API_RESOURCES in tests/conftest.py"
+    )
     dump = cognite_client_approval.dump()
     data_regression.check(dump, fullpath=SNAPSHOTS_DIR_CLEAN / f"{module_path.name}.yaml")

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -121,20 +121,8 @@ def mock_read_yaml_file(module_path: Path, monkeypatch: MonkeyPatch) -> None:
     monkeypatch.setattr("cognite_toolkit.cdf_tk.templates.read_yaml_file", fake_read_yaml_file)
 
 
-@pytest.mark.parametrize("module_path", list(find_all_modules()))
-def test_deploy_module_approval(
-    module_path: Path,
-    local_tmp_path: Path,
-    local_tmp_project_path: Path,
-    monkeypatch: MonkeyPatch,
-    cognite_client_approval: CogniteClient,
-    cdf_tool_config: CDFToolConfig,
-    typer_context: typer.Context,
-    data_regression,
-) -> None:
-    mock_read_yaml_files(module_path, monkeypatch)
-    mock_read_yaml_file(module_path, monkeypatch)
-
+@pytest.fixture
+def init_project(typer_context: typer.Context, local_tmp_project_path: Path) -> None:
     main_init(
         typer_context,
         dry_run=False,
@@ -144,6 +132,23 @@ def test_deploy_module_approval(
         no_backup=True,
         clean=True,
     )
+    return None
+
+
+@pytest.mark.parametrize("module_path", list(find_all_modules()))
+def test_deploy_module_approval(
+    module_path: Path,
+    local_tmp_path: Path,
+    local_tmp_project_path: Path,
+    monkeypatch: MonkeyPatch,
+    cognite_client_approval: CogniteClient,
+    cdf_tool_config: CDFToolConfig,
+    typer_context: typer.Context,
+    init_project: None,
+    data_regression,
+) -> None:
+    mock_read_yaml_files(module_path, monkeypatch)
+    mock_read_yaml_file(module_path, monkeypatch)
 
     build(
         typer_context,

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -166,6 +166,11 @@ def test_deploy_module_approval(
         dry_run=False,
         include=[],
     )
+    not_mocked = cognite_client_approval.not_mocked_calls()
+    assert not not_mocked, (
+        f"The following APIs have been called without being mocked: {not_mocked}, "
+        "Please update the _API_RESOURCES in tests/conftest.py"
+    )
 
     dump = cognite_client_approval.dump()
     data_regression.check(dump, fullpath=SNAPSHOTS_DIR / f"{module_path.name}.yaml")

--- a/tests/test_approval_modules_snapshots/cdf_data_pipeline_asset_valhall.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_data_pipeline_asset_valhall.yaml
@@ -7,6 +7,38 @@ DataSet:
     transformations: '[{"externalId": "tr_asset_oid_workmate_asset_hierarchy", "type":
       "Transformations"}]'
   name: asset:oid
+ExtractionPipeline:
+- dataSetId: 42
+  description: Asset source extraction pipeline with configuration for DB extractor
+    reading data from oid:workmate
+  documentation: "The DB Extractor is a general database extractor that connects to\
+    \ a database, executes one or several queries and sends the result to CDF RAW.\n\
+    \nThe extractor connects to a database over ODBC, which means that you need an\
+    \ ODBC driver for your database. If you are running the Docker version of the\
+    \ extractor, ODBC drivers for MySQL, MS SQL, PostgreSql and Oracle DB are preinstalled\
+    \ in the image. See the example config for details on connection strings for these.\
+    \ If you are running the Windows exe version of the extractor, you must provide\
+    \ an ODBC driver yourself. These are typically provided by the database vendor.\n\
+    \nFurther documentation is available [here](./docs/documentation.md)\n\nFor information\
+    \ on development, consider the following guides:\n\n * [Development guide](guides/development.md)\n\
+    \ * [Release guide](guides/release.md)"
+  externalId: ep_src_asset_oid_workmate
+  name: src:asset:oid:workmate
+  rawTables:
+  - dbName: asset_oid_workmate
+    tableName: assets
+  source: workmate
+ExtractionPipelineConfig:
+- config: "databases:\n-   connection-string: DSN={MyPostgresDsn}\n    name: postgres\n\
+    \    type: odbc\nlogger:\n    console:\n        level: INFO\n    file:\n     \
+    \   level: INFO\n        path: file.log\nqueries:\n-   database: postgres\n  \
+    \  destination:\n        database: db-extractor\n        table: postgres\n   \
+    \     type: raw\n    incremental-field: id\n    initial-start: 0\n    name: test-postgres\n\
+    \    primary-key: '{id}'\n    query: \"SELECT\\n\\n  *\\nFROM\\n\\n  mytable\\\
+    nWHERE\\n\\n  {incremental_field} >= '{start_at}'\\n\\\n        ORDER BY\\n\\\
+    n  {incremental_field} ASC\\n\"\n"
+  description: DB extractor config reading data from oid:workmate
+  externalId: ep_src_asset_oid_workmate
 Group:
 - capabilities:
   - rawAcl:
@@ -127,5 +159,7 @@ TransformationSchedule:
   interval: 7 * * * *
   isPaused: true
 deleted:
+  ExtractionPipeline:
+  - externalId: ep_src_asset_oid_workmate
   Transformation:
   - externalId: tr_asset_oid_workmate_asset_hierarchy

--- a/tests/test_approval_modules_snapshots_clean/cdf_data_pipeline_asset_valhall.yaml
+++ b/tests/test_approval_modules_snapshots_clean/cdf_data_pipeline_asset_valhall.yaml
@@ -1,3 +1,5 @@
 deleted:
+  ExtractionPipeline:
+  - externalId: ep_src_asset_oid_workmate
   Transformation:
   - externalId: tr_asset_oid_workmate_asset_hierarchy

--- a/tests/test_cdf_tk/test_load.py
+++ b/tests/test_cdf_tk/test_load.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from cognite.client import CogniteClient
 from cognite.client.data_classes import DataSet
 
 from cognite_toolkit.cdf_tk.load import (
@@ -13,6 +12,7 @@ from cognite_toolkit.cdf_tk.load import (
     deploy_or_clean_resources,
 )
 from cognite_toolkit.cdf_tk.utils import CDFToolConfig
+from tests.conftest import ApprovalCogniteClient
 
 THIS_FOLDER = Path(__file__).resolve().parent
 
@@ -28,11 +28,11 @@ SNAPSHOTS_DIR = THIS_FOLDER / "load_data_snapshots"
     ],
 )
 def test_loader_class(
-    loader_cls: type[Loader], directory: Path, cognite_client_approval: CogniteClient, data_regression
+    loader_cls: type[Loader], directory: Path, cognite_client_approval: ApprovalCogniteClient, data_regression
 ):
     cdf_tool = MagicMock(spec=CDFToolConfig)
-    cdf_tool.verify_client.return_value = cognite_client_approval
-    cdf_tool.verify_capabilities.return_value = cognite_client_approval
+    cdf_tool.verify_client.return_value = cognite_client_approval.mock_client
+    cdf_tool.verify_capabilities.return_value = cognite_client_approval.mock_client
     cdf_tool.data_set_id = 999
 
     deploy_or_clean_resources(
@@ -43,7 +43,7 @@ def test_loader_class(
     data_regression.check(dump, fullpath=SNAPSHOTS_DIR / f"{directory.name}.yaml")
 
 
-def test_upsert_data_set(cognite_client_approval: CogniteClient):
+def test_upsert_data_set(cognite_client_approval: ApprovalCogniteClient):
     cdf_tool = MagicMock(spec=CDFToolConfig)
     cdf_tool.verify_client.return_value = cognite_client_approval
     cdf_tool.verify_capabilities.return_value = cognite_client_approval
@@ -58,7 +58,7 @@ def test_upsert_data_set(cognite_client_approval: CogniteClient):
     first.created_time = 42
     first.last_updated_time = 42
     # Simulate that the data set is already in CDF
-    cognite_client_approval.data_sets.append(first)
+    cognite_client_approval.append(DataSet, first)
 
     changed = loader.remove_unchanged(loaded)
 

--- a/tests/test_cdf_tk/test_load.py
+++ b/tests/test_cdf_tk/test_load.py
@@ -45,8 +45,8 @@ def test_loader_class(
 
 def test_upsert_data_set(cognite_client_approval: ApprovalCogniteClient):
     cdf_tool = MagicMock(spec=CDFToolConfig)
-    cdf_tool.verify_client.return_value = cognite_client_approval
-    cdf_tool.verify_capabilities.return_value = cognite_client_approval
+    cdf_tool.verify_client.return_value = cognite_client_approval.mock_client
+    cdf_tool.verify_capabilities.return_value = cognite_client_approval.mock_client
 
     loader = DataSetsLoader.create_loader(cdf_tool)
     loaded = loader.load_resource(DATA_FOLDER / "data_sets" / "1.my_datasets.yaml", dry_run=False)


### PR DESCRIPTION
## Description
This PR does not do any changes to production code instead testing is changed.

#### Dry-run Test
This test runs the three commands `init`, `build` and `deploy` for each module with the `--dry-run` flag set, 
and verifies that no `create` or `delete` calls are made to any of the CDF resources. In addition, it checks that neither `verify_dataset`, `verify_space`, `verify_extraction_pipeline` have been called as these resources might not have been created.

#### Extend Approval Test
The existing test for deploying each module (`init`, `build`, and `deploy`) is extended to check that all CDF resources have been mocked (so we can log calls and intercept their creation calls). (Same extension for the `init`, `build`, `clean` test). 

If a resource has not been mocked then you get this error message: 
```
AssertionError: The following APIs have been called without being mocked:
 {'extraction_pipelines.config.create': 1, 'extraction_pipelines.config.list': 1, 
'extraction_pipelines.create': 1, 'extraction_pipelines.delete': 1}, Please update the _API_RESOURCES list in tests/conftest.py
```

Added mocking of the `extraction_pipeline` and `extraction_pipeline.config` as these two were not mocked. 

## Checklist:
- [x] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
