### PR TITLE
Missing extraction pipeline does not raise exception

### DIFF
--- a/cognite_toolkit/cdf_tk/utils.py
+++ b/cognite_toolkit/cdf_tk/utils.py
@@ -347,9 +347,11 @@ class CDFToolConfig:
 
         if pipeline is not None:
             return pipeline.id
-        raise ValueError(
-            f"Extraction pipeline {external_id} does not exist, you need to create it first. Do this by adding a config file to the extraction_pipelines folder."
-        )
+        else:
+            print(
+                f"  [bold yellow]WARNING[/] Extraction pipeline {external_id} does not exist. It may have been deleted, or not been part of the module."
+            )
+            return -1
 
     def verify_spaces(self, space: str | list[str]) -> list[str]:
         """Verify that the configured space exists and is accessible


### PR DESCRIPTION
## Description
"Softened" the extraction pipeline check since running loaders in sequence should make it unlikely to fail. Hence it shows a warning instead of raising an exception. 


## Checklist:
- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
