### PR TITLE
CDF-toolkit version in environments.yaml

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -75,6 +75,8 @@ Changes are grouped as follows:
 - Missing .sql files for transformations will now raise an error in the build step.
 - The build step will now raise a number of warnings for missing externalIds in the yaml files,
   as well as if the naming conventions are not followed.
+- System section in `environments.yaml` to track local state of `cdf-toolkit`.
+- Introduced a `build_environment.yaml` in the `/build` folder to track how the build was run.
 
 ### Fixed
 

--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -26,6 +26,9 @@ Changes are grouped as follows:
   
 ### Changed
 
+- **BREAKING** All externalIds and names have been changed to follow the naming conventions for resources
+  in `examples/cdf_oid_example_data`, `examples/cdf_apm_simple_data_model`, `modules/cdf_apm_base`,
+  `modules/cdf_infield_common`, and `modules/cdf_infield_location`.
 - All cognite templates have been moved into `cognite_templates` folder, while `local_templates` is renamed to `custom_templates`.
 - Move cdf_apm_base into separate folder.
 - The file `local.yaml` has been renamed `environments.yaml` to better reflect its purpose.
@@ -39,15 +42,8 @@ Changes are grouped as follows:
 
 - Removed transformation identity provider variables from modules and reused the global cicd_ prefixed ones.
 
-## [0.2.0] - 2023-12-01
 
-### Changed
-
-- **BREAKING** All externalIds and names have been changed to follow the naming conventions for resources
-  in `examples/cdf_oid_example_data`, `examples/cdf_apm_simple_data_model`, `modules/cdf_apm_base`,
-  `modules/cdf_infield_common`, and `modules/cdf_infield_location`.
-
-## [0.1.2] - 2023-11-29
+## [0.1.0a3] - 2023-11-29
 
 ### Changed
 
@@ -61,7 +57,7 @@ Changes are grouped as follows:
 - Fix wrong reference to `apm_simple` in `examples/cdf_apm_simple_data_model` and `modules/cdf_infield_location`.
 - Exemplify use of a single config yaml file for multiple file resources in `examples/cdf_oid_example_data/files/files.yaml`.
 
-## [0.1.1] - 2023-11-23
+## [0.1.0a2] - 2023-11-23
 
 ### Changed
 
@@ -76,6 +72,6 @@ Changes are grouped as follows:
 - cdf_infield_common module and the auth applications-configuration.yaml did not load group source id
    correctly due to source_id being used instead of sourceId. This is now fixed.
 
-## [0.1.0] - 2023-11-21
+## [0.1.0a1] - 2023-11-21
 
 Initial release

--- a/cognite_toolkit/_version.py
+++ b/cognite_toolkit/_version.py
@@ -1,2 +1,1 @@
 __version__ = "0.1.0a3"
-__template_version__ = "0.2.0"

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -58,7 +58,7 @@ class Common:
 
 def _version_callback(value: bool):
     if value:
-        typer.echo(f"CDF-Toolkit version: {_version.__version__}, Template version: {_version.__template_version__}")
+        typer.echo(f"CDF-Toolkit version: {_version.__version__}.")
         raise typer.Exit()
 
 

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -28,9 +28,11 @@ from cognite_toolkit.cdf_tk.templates import (
     CONFIG_FILE,
     CUSTOM_MODULES,
     ENVIRONMENTS_FILE,
+    BuildEnvironment,
     build_config,
     generate_config,
     read_environ_config,
+    read_yaml_file,
 )
 from cognite_toolkit.cdf_tk.utils import CDFToolConfig
 
@@ -188,13 +190,14 @@ def build(
             f"\n[bold]Environment file:[/] {environment_file.absolute().relative_to(Path.cwd())!s} and [bold]config file:[/] {config_file.absolute().relative_to(Path.cwd())!s}"
         )
     )
+    print(f"  Environment is {build_env}, using that section in {ENVIRONMENTS_FILE!s}.\n")
+    build_ = BuildEnvironment.load(read_yaml_file(environment_file), build_env)
 
     build_config(
         build_dir=Path(build_dir),
         source_dir=source_dir,
         config_file=config_file,
-        environment_file=environment_file,
-        build_env=build_env,
+        build=build_,
         clean=clean,
         verbose=ctx.obj.verbose,
     )

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -191,7 +191,7 @@ def build(
         )
     )
     print(f"  Environment is {build_env}, using that section in {ENVIRONMENTS_FILE!s}.\n")
-    build_ = BuildEnvironment.load(read_yaml_file(environment_file), build_env)
+    build_ = BuildEnvironment.load(read_yaml_file(environment_file), build_env, "build")
     build_.set_environment_variables()
 
     build_config(
@@ -262,7 +262,7 @@ def deploy(
     else:
         ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.project)
 
-    build_ = BuildEnvironment.load(read_yaml_file(Path(build_dir) / BUILD_ENVIRONMENT_FILE), build_env)
+    build_ = BuildEnvironment.load(read_yaml_file(Path(build_dir) / BUILD_ENVIRONMENT_FILE), build_env, "deploy")
     build_.set_environment_variables()
 
     print(Panel(f"[bold]Deploying config files from {build_dir} to environment {build_env}...[/]"))
@@ -384,7 +384,7 @@ def clean(
     else:
         ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.project)
 
-    build_ = BuildEnvironment.load(read_yaml_file(Path(build_dir) / BUILD_ENVIRONMENT_FILE), build_env)
+    build_ = BuildEnvironment.load(read_yaml_file(Path(build_dir) / BUILD_ENVIRONMENT_FILE), build_env, "clean")
     build_.set_environment_variables()
 
     Panel(f"[bold]Cleaning environment {build_env} based on config files from {build_dir}...[/]")

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -24,6 +24,7 @@ from cognite_toolkit.cdf_tk.load import (
     deploy_or_clean_resources,
 )
 from cognite_toolkit.cdf_tk.templates import (
+    BUILD_ENVIRONMENT_FILE,
     COGNITE_MODULES,
     CONFIG_FILE,
     CUSTOM_MODULES,
@@ -31,7 +32,6 @@ from cognite_toolkit.cdf_tk.templates import (
     BuildEnvironment,
     build_config,
     generate_config,
-    read_environ_config,
     read_yaml_file,
 )
 from cognite_toolkit.cdf_tk.utils import CDFToolConfig
@@ -192,6 +192,7 @@ def build(
     )
     print(f"  Environment is {build_env}, using that section in {ENVIRONMENTS_FILE!s}.\n")
     build_ = BuildEnvironment.load(read_yaml_file(environment_file), build_env)
+    build_.set_environment_variables()
 
     build_config(
         build_dir=Path(build_dir),
@@ -260,8 +261,9 @@ def deploy(
         ToolGlobals = ctx.obj.mockToolGlobals
     else:
         ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.project)
-    # Set environment variables from local.yaml
-    read_environ_config(root_dir=build_dir, build_env=build_env, set_env_only=True)
+
+    build_ = BuildEnvironment.load(read_yaml_file(Path(build_dir) / BUILD_ENVIRONMENT_FILE), build_env)
+    build_.set_environment_variables()
 
     print(Panel(f"[bold]Deploying config files from {build_dir} to environment {build_env}...[/]"))
     build_path = Path(build_dir)
@@ -382,8 +384,8 @@ def clean(
     else:
         ToolGlobals = CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.project)
 
-    # Set environment variables from local.yaml
-    read_environ_config(root_dir=build_dir, build_env=build_env, set_env_only=True)
+    build_ = BuildEnvironment.load(read_yaml_file(Path(build_dir) / BUILD_ENVIRONMENT_FILE), build_env)
+    build_.set_environment_variables()
 
     Panel(f"[bold]Cleaning environment {build_env} based on config files from {build_dir}...[/]")
     build_path = Path(build_dir)

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -17,8 +17,6 @@ from rich.panel import Panel
 
 from cognite_toolkit import _version
 from cognite_toolkit.cdf_tk import bootstrap
-
-# from scripts.delete import clean_out_datamodels
 from cognite_toolkit.cdf_tk.load import (
     LOADER_BY_FOLDER_NAME,
     AuthLoader,
@@ -43,7 +41,7 @@ auth_app = typer.Typer(
 app.add_typer(auth_app, name="auth")
 
 
-_AVAILABLE_DATA_TYPES: tuple[str] = tuple(LOADER_BY_FOLDER_NAME)
+_AVAILABLE_DATA_TYPES: tuple[str, ...] = tuple(LOADER_BY_FOLDER_NAME)
 
 
 # Common parameters handled in common callback

--- a/cognite_toolkit/cdf_tk/templates.py
+++ b/cognite_toolkit/cdf_tk/templates.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, overload
 import yaml
 from rich import print
 
+from cognite_toolkit import _version
 from cognite_toolkit.cdf_tk.load import LOADER_BY_FOLDER_NAME
 from cognite_toolkit.cdf_tk.utils import validate_case_raw, validate_config_yaml, validate_data_set_is_set
 
@@ -112,12 +113,22 @@ class SystemVariables:
     @classmethod
     def load(cls, data: dict[str, Any]) -> SystemVariables:
         try:
-            return SystemVariables(cdf_toolkit_version=data["__system"]["cdf_toolkit_version"])
+            system = SystemVariables(cdf_toolkit_version=data["__system"]["cdf_toolkit_version"])
         except KeyError:
             print(
                 f"  [bold red]ERROR:[/] System variables are missing required field 'cdf_toolkit_version' in {ENVIRONMENTS_FILE!s}"
             )
-        exit(1)
+            exit(1)
+        if system.cdf_toolkit_version != _version.__version__:
+            print(
+                f"  [bold red]Error:[/] The version of the templates ({system.cdf_toolkit_version}) does not match the version of the installed package ({_version.__version__})."
+            )
+            print("  Please run `cdf-tk init --upgrade` to upgrade the templates OR.")
+            print(
+                f"  Please run `pip install cognite-toolkit==={system.cdf_toolkit_version}` to downgrade the installed package."
+            )
+            exit(1)
+        return system
 
 
 def read_environ_config(

--- a/cognite_toolkit/cdf_tk/templates.py
+++ b/cognite_toolkit/cdf_tk/templates.py
@@ -110,19 +110,18 @@ class SystemVariables:
 
     @classmethod
     def load(cls, data: dict[str, Any], action: Literal["build", "deploy", "clean"]) -> SystemVariables:
+        file_name = BUILD_ENVIRONMENT_FILE if action in {"deploy", "clean"} else ENVIRONMENTS_FILE
         try:
             system = SystemVariables(cdf_toolkit_version=data["__system"]["cdf_toolkit_version"])
         except KeyError:
             print(
-                f"  [bold red]ERROR:[/] System variables are missing required field 'cdf_toolkit_version' in {ENVIRONMENTS_FILE!s}"
+                f"  [bold red]ERROR:[/] System variables are missing required field 'cdf_toolkit_version' in {file_name!s}"
             )
             if action in {"deploy", "clean"}:
-                print(
-                    f"  rerun `cdf-tk build` to build the templates again with `{BUILD_ENVIRONMENT_FILE!s}` created correctly."
-                )
+                print(f"  rerun `cdf-tk build` to build the templates again and create `{file_name!s}` correctly.")
             elif action == "build":
                 print(
-                    f"  rerun `cdf-tk init` to initialize with the flag `--upgrade` the templates again with `{BUILD_ENVIRONMENT_FILE!s}` created correctly."
+                    f"  run `cdf-tk init --upgrade` to initialize the templates again and create a correct `{file_name!s}` file."
                 )
             exit(1)
         if system.cdf_toolkit_version != _version.__version__:

--- a/cognite_toolkit/environments.yaml
+++ b/cognite_toolkit/environments.yaml
@@ -47,7 +47,6 @@ prod:
 
 
 # DO NOT EDIT THE LINES BELOW!
-# This part is used by cdf-toolkit to keep track of version and help you upgrade.
+# This part is used by cdf-toolkit to keep track of the version and help you upgrade.
 __system:
   cdf_toolkit_version: 0.1.0a3
-

--- a/cognite_toolkit/environments.yaml
+++ b/cognite_toolkit/environments.yaml
@@ -45,3 +45,9 @@ prod:
   deploy:
     - cdf_infield
 
+
+# DO NOT EDIT THE LINES BELOW!
+# This part is used by cdf-toolkit to keep track of version and help you upgrade.
+__system:
+  cdf_toolkit_version: 0.1.0a3
+

--- a/demo/environments.yaml
+++ b/demo/environments.yaml
@@ -22,3 +22,8 @@ demo:
     - cdf_demo_infield
     - cdf_oid_example_data
     - cdf_data_pipeline_asset_valhall
+
+# DO NOT EDIT THE LINES BELOW!
+# This part is used by cdf-toolkit to keep track of the version and help you upgrade.
+__system:
+  cdf_toolkit_version: 0.1.0a3

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -19,7 +19,7 @@ from cognite.client import CogniteClient
 from pytest import MonkeyPatch
 
 from cognite_toolkit.cdf import Common, build, clean, deploy, main_init
-from cognite_toolkit.cdf_tk.templates import COGNITE_MODULES, iterate_modules, read_yaml_file, read_yaml_files
+from cognite_toolkit.cdf_tk.templates import COGNITE_MODULES, iterate_modules, read_yaml_file
 from cognite_toolkit.cdf_tk.utils import CDFToolConfig
 
 REPO_ROOT = Path(__file__).parent.parent
@@ -98,18 +98,6 @@ def typer_context(cdf_tool_config: CDFToolConfig) -> typer.Context:
     return context
 
 
-def mock_read_yaml_files(module_path: Path, monkeypatch: MonkeyPatch) -> None:
-    def fake_read_yaml_files(
-        yaml_dirs: list[str],
-        name: str | None = None,
-    ) -> dict[str, Any]:
-        if name == "local.yaml":
-            return {"dev": {"project": "pytest-project", "type": "dev", "deploy": [module_path.name]}}
-        return read_yaml_files(yaml_dirs, name)
-
-    monkeypatch.setattr("cognite_toolkit.cdf_tk.templates.read_yaml_files", fake_read_yaml_files)
-
-
 def mock_read_yaml_file(module_path: Path, monkeypatch: MonkeyPatch) -> None:
     def fake_read_yaml_file(
         filepath: Path, expected_output: Literal["list", "dict"] = "dict"
@@ -132,7 +120,6 @@ def test_deploy_module_approval(
     typer_context: typer.Context,
     data_regression,
 ) -> None:
-    mock_read_yaml_files(module_path, monkeypatch)
     mock_read_yaml_file(module_path, monkeypatch)
 
     main_init(
@@ -177,7 +164,6 @@ def test_clean_module_approval(
     typer_context: typer.Context,
     data_regression,
 ) -> None:
-    mock_read_yaml_files(module_path, monkeypatch)
     mock_read_yaml_file(module_path, monkeypatch)
 
     main_init(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,7 +8,7 @@ import pytest
 import yaml
 from packaging.version import Version
 
-from cognite_toolkit._version import __template_version__, __version__
+from cognite_toolkit._version import __version__
 from cognite_toolkit.cdf_tk.templates import generate_config
 from tests.constants import REPO_ROOT
 
@@ -29,7 +29,7 @@ def test_pyproj_version_matches() -> None:
 
 @pytest.mark.parametrize(
     "package_version, changelog_name",
-    [(__version__, "CHANGELOG.cdf-tk.md"), (__template_version__, "CHANGELOG.templates.md")],
+    [(__version__, "CHANGELOG.cdf-tk.md"), (__version__, "CHANGELOG.templates.md")],
 )
 def test_changelog_entry_version_matches(package_version: str, changelog_name: str) -> None:
     match = next(_parse_changelog(changelog_name))

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -82,6 +82,17 @@ def test_config_yaml_updated() -> None:
     )
 
 
+def test_environment_system_variables_updated() -> None:
+    environments_yaml = yaml.safe_load(
+        (REPO_ROOT / "cognite_toolkit" / "environments.yaml").read_text(encoding="utf-8")
+    )
+    system_variables = environments_yaml["__system"]
+
+    assert (
+        system_variables["cdf_toolkit_version"] == __version__
+    ), "The 'cdf_tk_version' system variable is not up to date."
+
+
 def _parse_changelog(changelog: str) -> Iterator[Match[str]]:
     changelog = (REPO_ROOT / changelog).read_text(encoding="utf-8")
     return re.finditer(r"##\s\[(\d+\.\d+\.\d+(a\d+)?)\]\s-\s(\d+-\d+-\d+)", changelog)


### PR DESCRIPTION
## Description
Introduced a `build_environment.yaml` in the build folder to track the state used for running the build.

## Checklist:
- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
