### PR TITLE
CDF-20462: Add data sets to the infield_location module

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -24,7 +24,7 @@ Changes are grouped as follows:
 - Check for whether template variables `<change_me>` are present in the config files.
 - Check for whether data set id is present in the config files.
 - Print table at the end of `cdf-tk deploy` with the resources that were created, deleted, and skipped.
-- Support for Extraction Pipelines and Extraction Pipeline configuration for remotely configured Extractors 
+- Support for Extraction Pipelines and Extraction Pipeline configuration for remotely configured Extractors
 
 ### Removed
 

--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -34,6 +34,8 @@ Changes are grouped as follows:
 - Combined the child and parent transformations `sync_assets_from_hierarchy_to_apm` in `cdf_infield_location`. 
   This has the benefit of not having to wait for the parent transformation to finish before starting the child transformation, 
   thus no longer a dependency between the two transformations.
+- Added all datasets to the `cdf_infield_locaton` module that previously were just a template, but created in `cdf_oid_example_data`.
+  If both modules are used, the datasets will be attempted created twice, but this is not a problem.
 
 ### Fixed
 

--- a/cognite_toolkit/cognite_modules/infield/cdf_infield_location/data_sets/location_source_data_set.yaml
+++ b/cognite_toolkit/cognite_modules/infield/cdf_infield_location/data_sets/location_source_data_set.yaml
@@ -1,18 +1,17 @@
-# NOTE!!! If you do not have an existing data set with asset data, you need to create one for
-# each Infield location. Rename this file to .yaml and change the configuration to match your data set.
-# 
+# NOTE!!! These data sets are also created in the cdf_oid_example_data module to
+# ensure that they are created independent on whether the demo data are used.
 - externalId: ds_asset_{{default_location}}
   name: asset:{{default_location}}
   description: This dataset contains asset data for the {{default_location}} location.
-- externalId: ds_3d_{{default_location}}
-  name: 3d:{{default_location}}
-  description: This dataset contains 3D data for the {{default_location}} location.
 - externalId: ds_files_{{default_location}}
   name: files:{{default_location}}
   description: This dataset contains files for the {{default_location}} location.
 - externalId: ds_timeseries_{{default_location}}
   name: timeseries:{{default_location}}
-  description: This dataset contains timeseries data for the {{default_location}} location.
+  description: This dataset contains timeseries for the {{default_location}} location.
+- externalId: ds_3d_{{default_location}}
+  name: 3d:{{default_location}}
+  description: This dataset contains 3D data for the {{default_location}} location.
 - externalId: ds_relationships_{{default_location}}
   name: relationships:{{default_location}}
   description: This dataset contains relationships data for the {{default_location}} location.

--- a/tests/test_approval_modules_snapshots/cdf_infield_location.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_infield_location.yaml
@@ -1,7 +1,22 @@
 DataSet:
+- description: This dataset contains 3D data for the oid location.
+  externalId: ds_3d_oid
+  name: 3d:oid
+- description: This dataset contains asset data for the oid location.
+  externalId: ds_asset_oid
+  name: asset:oid
+- description: This dataset contains files for the oid location.
+  externalId: ds_files_oid
+  name: files:oid
 - description: This dataset is for writing data from Infield for the location oid.
   externalId: ds_infield_oid_app_data
   name: infield:oid:app_data
+- description: This dataset contains relationships data for the oid location.
+  externalId: ds_relationships_oid
+  name: relationships:oid
+- description: This dataset contains timeseries for the oid location.
+  externalId: ds_timeseries_oid
+  name: timeseries:oid
 Group:
 - capabilities:
   - groupsAcl:


### PR DESCRIPTION
## Description
Add datasets to cdf_infield_location that previously were just templats.

## Checklist:
- [x] Tests added/updated.
- [x] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [x] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
