### PR TITLE
Bugfix from Testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,4 @@ config.yaml
 !demo/config.yaml
 demo_project/
 tests/pytest-project/
+my_project/

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,14 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.1.0b2] - 2023-12-TDB
+### Fixed
+- Handle duplicate `TransformationSchedules` when loading `Transformation` resources.
+- Print table at the end of `cdf-tk deploy` failed with `AttributeError` is a resource 
+  returned empty. This is now fixed.
+- The `cdf-tk build` command no longer gives a warning about missing `sql` file for 
+  `TransformationSchedule`s.
+
 ## [0.1.0b1] - 2023-12-15
 
 ### Added

--- a/CHANGELOG.templates.md
+++ b/CHANGELOG.templates.md
@@ -14,7 +14,11 @@ Changes are grouped as follows:
 - `Removed` for now removed features.
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
-  
+
+## [0.1.0b2] - 2023-12-TDB
+### Fixed
+- In the package `example_pump` ensure all transformations are prefixed with `tr_`.
+
 ## [0.1.0b1] - 2023-12-15
 
 ### Added

--- a/cognite_toolkit/cdf_tk/load.py
+++ b/cognite_toolkit/cdf_tk/load.py
@@ -1312,7 +1312,7 @@ class DeployResults(UserList):
         table.add_column(f"{prefix}Deleted", justify="right", style="red")
         table.add_column(f"{prefix}Skipped", justify="right", style="yellow")
         table.add_column("Total", justify="right")
-        for item in sorted(self.data):
+        for item in sorted(entry for entry in self.data if entry is not None):
             table.add_row(
                 item.name,
                 str(item.created),

--- a/cognite_toolkit/cdf_tk/load.py
+++ b/cognite_toolkit/cdf_tk/load.py
@@ -1283,11 +1283,17 @@ class DeployResult:
     skipped: int
     total: int
 
-    def __lt__(self, other):
-        return self.name < other.name
+    def __lt__(self, other: DeployResult) -> bool:
+        if isinstance(other, DeployResult):
+            return self.name < other.name
+        else:
+            return NotImplemented
 
-    def __eq__(self, other):
-        return self.name == other.name
+    def __eq__(self, other: DeployResult) -> bool:
+        if isinstance(other, DeployResult):
+            return self.name == other.name
+        else:
+            return NotImplemented
 
 
 class DeployResults(UserList):

--- a/cognite_toolkit/cdf_tk/templates.py
+++ b/cognite_toolkit/cdf_tk/templates.py
@@ -283,7 +283,7 @@ def check_yaml_semantics(parsed: Any, filepath_src: Path, filepath_build: Path, 
             print(
                 f"      [bold yellow]WARNING:[/] the group {filepath_src} has a name [bold]{ext_id}[/] without the recommended `gp_` based prefix."
             )
-    elif resource_type == "transformations":
+    elif resource_type == "transformations" and not filepath_src.stem.endswith("schedule"):
         # First try to find the sql file next to the yaml file with the same name
         sql_file1 = filepath_src.parent / f"{filepath_src.stem}.sql"
         if not sql_file1.exists():

--- a/cognite_toolkit/cognite_modules/examples/example_pump_asset_hierarchy/transformations/pump_asset_hierarchy-load-collections_pump.schedule.yaml
+++ b/cognite_toolkit/cognite_modules/examples/example_pump_asset_hierarchy/transformations/pump_asset_hierarchy-load-collections_pump.schedule.yaml
@@ -1,3 +1,3 @@
-externalId: pump_asset_hierarchy-load-collections_pump
+externalId: tr_pump_asset_hierarchy-load-collections_pump
 interval: '{{scheduleHourly}}'
 isPaused: true

--- a/cognite_toolkit/cognite_modules/experimental/cdf_asset_source_model/transformations/sync-asset_hierarchy_cdf_asset_source_model.schedule.yaml
+++ b/cognite_toolkit/cognite_modules/experimental/cdf_asset_source_model/transformations/sync-asset_hierarchy_cdf_asset_source_model.schedule.yaml
@@ -1,3 +1,3 @@
-externalId: sync-asset_hierarchy_cdf_asset_source_model
+externalId: tr_sync-asset_hierarchy_cdf_asset_source_model
 interval: '{{scheduleHourly}}'
 isPaused: true

--- a/cognite_toolkit/cognite_modules/experimental/example_pump_data_model/transformations/pump_model-populate-lift_station_pumps_edges.schedule.yaml
+++ b/cognite_toolkit/cognite_modules/experimental/example_pump_data_model/transformations/pump_model-populate-lift_station_pumps_edges.schedule.yaml
@@ -1,3 +1,3 @@
-externalId: pump_model-populate-lift_station_pumps_edges
+externalId: tr_pump_model-populate-lift_station_pumps_edges
 interval: '{{scheduleHourly}}'
 isPaused: true

--- a/cognite_toolkit/cognite_modules/experimental/example_pump_data_model/transformations/pump_model-populate-pump_container.schedule.yaml
+++ b/cognite_toolkit/cognite_modules/experimental/example_pump_data_model/transformations/pump_model-populate-pump_container.schedule.yaml
@@ -1,3 +1,3 @@
-externalId: pump_model-populate-pump_container
+externalId: tr_pump_model-populate-pump_container
 interval: '{{scheduleHourly}}'
 isPaused: true

--- a/tests/test_approval_modules_snapshots/cdf_asset_source_model.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_asset_source_model.yaml
@@ -88,7 +88,7 @@ Transformation:
     scopes: ${IDP_SCOPES}
     tokenUri: ${IDP_TOKEN_URL}
 TransformationSchedule:
-- externalId: sync-asset_hierarchy_cdf_asset_source_model
+- externalId: tr_sync-asset_hierarchy_cdf_asset_source_model
   interval: 7 * * * *
   isPaused: true
 View:
@@ -118,7 +118,7 @@ deleted:
   Transformation:
   - externalId: tr_sync-asset_hierarchy_cdf_asset_source_model
   TransformationSchedule:
-  - externalId: sync-asset_hierarchy_cdf_asset_source_model
+  - externalId: tr_sync-asset_hierarchy_cdf_asset_source_model
   View:
   - externalId: Asset
     space: sp_extended_source_data_models

--- a/tests/test_approval_modules_snapshots/example_pump_asset_hierarchy.yaml
+++ b/tests/test_approval_modules_snapshots/example_pump_asset_hierarchy.yaml
@@ -84,7 +84,7 @@ Transformation:
     scopes: ${IDP_SCOPES}
     tokenUri: ${IDP_TOKEN_URL}
 TransformationSchedule:
-- externalId: pump_asset_hierarchy-load-collections_pump
+- externalId: tr_pump_asset_hierarchy-load-collections_pump
   interval: 7 * * * *
   isPaused: true
 deleted:
@@ -95,4 +95,4 @@ deleted:
   Transformation:
   - externalId: tr_pump_asset_hierarchy-load-collections_pump
   TransformationSchedule:
-  - externalId: pump_asset_hierarchy-load-collections_pump
+  - externalId: tr_pump_asset_hierarchy-load-collections_pump

--- a/tests/test_approval_modules_snapshots/example_pump_data_model.yaml
+++ b/tests/test_approval_modules_snapshots/example_pump_data_model.yaml
@@ -139,10 +139,10 @@ Transformation:
     scopes: ${IDP_SCOPES}
     tokenUri: ${IDP_TOKEN_URL}
 TransformationSchedule:
-- externalId: pump_model-populate-lift_station_pumps_edges
+- externalId: tr_pump_model-populate-lift_station_pumps_edges
   interval: 7 * * * *
   isPaused: true
-- externalId: pump_model-populate-pump_container
+- externalId: tr_pump_model-populate-pump_container
   interval: 7 * * * *
   isPaused: true
 View:
@@ -248,8 +248,8 @@ deleted:
   - externalId: tr_pump_model-populate-lift_station_pumps_edges
   - externalId: tr_pump_model-populate-pump_container
   TransformationSchedule:
-  - externalId: pump_model-populate-lift_station_pumps_edges
-  - externalId: pump_model-populate-pump_container
+  - externalId: tr_pump_model-populate-lift_station_pumps_edges
+  - externalId: tr_pump_model-populate-pump_container
   View:
   - externalId: LiftStation
     space: sp_pump_model_space

--- a/tests/test_approval_modules_snapshots_clean/cdf_asset_source_model.yaml
+++ b/tests/test_approval_modules_snapshots_clean/cdf_asset_source_model.yaml
@@ -14,7 +14,7 @@ deleted:
   Transformation:
   - externalId: tr_sync-asset_hierarchy_cdf_asset_source_model
   TransformationSchedule:
-  - externalId: sync-asset_hierarchy_cdf_asset_source_model
+  - externalId: tr_sync-asset_hierarchy_cdf_asset_source_model
   View:
   - externalId: Asset
     space: sp_extended_source_data_models

--- a/tests/test_approval_modules_snapshots_clean/example_pump_asset_hierarchy.yaml
+++ b/tests/test_approval_modules_snapshots_clean/example_pump_asset_hierarchy.yaml
@@ -6,4 +6,4 @@ deleted:
   Transformation:
   - externalId: tr_pump_asset_hierarchy-load-collections_pump
   TransformationSchedule:
-  - externalId: pump_asset_hierarchy-load-collections_pump
+  - externalId: tr_pump_asset_hierarchy-load-collections_pump

--- a/tests/test_approval_modules_snapshots_clean/example_pump_data_model.yaml
+++ b/tests/test_approval_modules_snapshots_clean/example_pump_data_model.yaml
@@ -15,8 +15,8 @@ deleted:
   - externalId: tr_pump_model-populate-lift_station_pumps_edges
   - externalId: tr_pump_model-populate-pump_container
   TransformationSchedule:
-  - externalId: pump_model-populate-lift_station_pumps_edges
-  - externalId: pump_model-populate-pump_container
+  - externalId: tr_pump_model-populate-lift_station_pumps_edges
+  - externalId: tr_pump_model-populate-pump_container
   View:
   - externalId: LiftStation
     space: sp_pump_model_space


### PR DESCRIPTION
## Description
### Fixed
- Handle duplicate `TransformationSchedules` when loading `Transformation` resources.
- Print table at the end of `cdf-tk deploy` failed with `AttributeError` is a resource 
  returned empty. This is now fixed.
- The `cdf-tk build` command no longer gives a warning about missing `sql` file for 
  `TransformationSchedule`s.


## Checklist:
- [x] Tests added/updated.
- [x] Run Demo Job Locally.
- [ ] Documentation updated.
- [x] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [x] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
