### PR TITLE
Bugfix: Skipping auth

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,12 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [0.1.0b3] - TBD
+### Fixed
+
+- Fixed bug in `cdf-tk deploy` where auth groups with a mix of all and resource scoped capabilities skipped 
+  the all scoped capabilities. This is now fixed.
+
 ## [0.1.0b2] - 2023-12-17
 
 ### Fixed

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -341,7 +341,7 @@ def deploy(
         # Last, we need to get all the scoped access, as the resources should now have been created.
         print("[bold]EVALUATING auth resources scoped to resources...[/]")
         result = deploy_or_clean_resources(
-            AuthLoader.create_loader(ToolGlobals, target_scopes="resource_scoped_only"),
+            AuthLoader.create_loader(ToolGlobals, target_scopes="all"),
             directory,
             **arguments,
         )

--- a/cognite_toolkit/cdf.py
+++ b/cognite_toolkit/cdf.py
@@ -338,7 +338,8 @@ def deploy(
             exit(1)
 
     if "auth" in include and (directory := (Path(build_dir) / "auth")).is_dir():
-        # Last, we need to get all the scoped access, as the resources should now have been created.
+        # Last, we create the Groups again, but this time we do not filter out any capabilities
+        # and we do not skip validation as the resources should now have been created.
         print("[bold]EVALUATING auth resources scoped to resources...[/]")
         result = deploy_or_clean_resources(
             AuthLoader.create_loader(ToolGlobals, target_scopes="all"),

--- a/tests/test_approval_modules.py
+++ b/tests/test_approval_modules.py
@@ -168,6 +168,12 @@ def test_deploy_module_approval(
     dump = cognite_client_approval.dump()
     data_regression.check(dump, fullpath=SNAPSHOTS_DIR / f"{module_path.name}.yaml")
 
+    for group_calls in cognite_client_approval.auth_create_group_calls():
+        lost_capabilities = group_calls.capabilities_all_calls - group_calls.last_created_capabilities
+        assert (
+            not lost_capabilities
+        ), f"The group {group_calls.name!r} has lost the capabilities: {', '.join(lost_capabilities)}"
+
 
 @pytest.mark.parametrize("module_path", list(find_all_modules()))
 def test_deploy_dry_run_module_approval(

--- a/tests/test_approval_modules_snapshots/cdf_auth_readwrite_all.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_auth_readwrite_all.yaml
@@ -159,6 +159,344 @@ Group:
       actions:
       - LIST
       - READ
+      scope:
+        all: {}
+  - threedAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - assetsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - eventsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - filesAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - rawAcl:
+      actions:
+      - READ
+      - LIST
+      scope:
+        all: {}
+  - relationshipsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - timeSeriesAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - dataModelsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - dataModelInstancesAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - datasetsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - extractionPipelinesAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - extractionRunsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - extractionConfigsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - functionsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - sessionsAcl:
+      actions:
+      - LIST
+      scope:
+        all: {}
+  - transformationsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - entitymatchingAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - documentPipelinesAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - filePipelinesAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - annotationsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - documentFeedbackAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - securityCategoriesAcl:
+      actions:
+      - LIST
+      scope:
+        all: {}
+  - hostedExtractorsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - visionModelAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - roboticsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - geospatialAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  metadata:
+    origin: cdf-project-templates
+  name: gp_cicd_all_read_only
+  sourceId: <change_me>
+- capabilities:
+  - projectsAcl:
+      actions:
+      - LIST
+      - READ
+      scope:
+        all: {}
+  - groupsAcl:
+      actions:
+      - LIST
+      - READ
+      - CREATE
+      - UPDATE
+      - DELETE
+      scope:
+        all: {}
+  - threedAcl:
+      actions:
+      - READ
+      - CREATE
+      - UPDATE
+      - DELETE
+      scope:
+        all: {}
+  - assetsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - eventsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - filesAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - rawAcl:
+      actions:
+      - READ
+      - WRITE
+      - LIST
+      scope:
+        all: {}
+  - relationshipsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - timeSeriesAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - dataModelsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - dataModelInstancesAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - datasetsAcl:
+      actions:
+      - READ
+      - WRITE
+      - OWNER
+      scope:
+        all: {}
+  - extractionPipelinesAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - extractionRunsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - extractionConfigsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - functionsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - sessionsAcl:
+      actions:
+      - LIST
+      - CREATE
+      - DELETE
+      scope:
+        all: {}
+  - transformationsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - entitymatchingAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - documentPipelinesAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - filePipelinesAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - annotationsAcl:
+      actions:
+      - WRITE
+      - READ
+      - SUGGEST
+      - REVIEW
+      scope:
+        all: {}
+  - documentFeedbackAcl:
+      actions:
+      - CREATE
+      - READ
+      - DELETE
+      scope:
+        all: {}
+  - securityCategoriesAcl:
+      actions:
+      - MEMBEROF
+      - LIST
+      - CREATE
+      - UPDATE
+      - DELETE
+      scope:
+        all: {}
+  - hostedExtractorsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - visionModelAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - roboticsAcl:
+      actions:
+      - READ
+      - CREATE
+      - UPDATE
+      - DELETE
+      scope:
+        all: {}
+  - geospatialAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  metadata:
+    origin: cdf-project-templates
+  name: gp_cicd_all_read_write
+  sourceId: <change_me>
+- capabilities:
+  - projectsAcl:
+      actions:
+      - LIST
+      - READ
+      scope:
+        all: {}
+  - groupsAcl:
+      actions:
+      - LIST
+      - READ
       - CREATE
       - UPDATE
       - DELETE

--- a/tests/test_approval_modules_snapshots/cdf_data_pipeline_asset_valhall.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_data_pipeline_asset_valhall.yaml
@@ -91,6 +91,19 @@ Group:
           dbsToTables:
             asset_oid_workmate:
               tables: []
+  - transformationsAcl:
+      actions:
+      - READ
+      - WRITE
+      scope:
+        all: {}
+  - sessionsAcl:
+      actions:
+      - LIST
+      - CREATE
+      - DELETE
+      scope:
+        all: {}
   - assetsAcl:
       actions:
       - READ

--- a/tests/test_approval_modules_snapshots/cdf_infield_common.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_infield_common.yaml
@@ -20,6 +20,27 @@ Group:
     origin: cdf-project-templates
   name: applications-configuration
   sourceId: <change_me>
+- capabilities:
+  - groupsAcl:
+      actions:
+      - LIST
+      - READ
+      scope:
+        currentuserscope: {}
+  - threedAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  - assetsAcl:
+      actions:
+      - READ
+      scope:
+        all: {}
+  metadata:
+    origin: cdf-project-templates
+  name: applications-configuration
+  sourceId: <change_me>
 Space:
 - description: Space for Infield App Data
   name: cognite_app_data

--- a/tests/test_approval_modules_snapshots/cdf_infield_location.yaml
+++ b/tests/test_approval_modules_snapshots/cdf_infield_location.yaml
@@ -34,6 +34,12 @@ Group:
   name: gp_infield_oid_checklist_admins
   sourceId: <change_me>
 - capabilities:
+  - groupsAcl:
+      actions:
+      - LIST
+      - READ
+      scope:
+        currentuserscope: {}
   - threedAcl:
       actions:
       - READ
@@ -134,6 +140,12 @@ Group:
   name: gp_infield_oid_normal_users
   sourceId: <change_me>
 - capabilities:
+  - groupsAcl:
+      actions:
+      - LIST
+      - READ
+      scope:
+        currentuserscope: {}
   - threedAcl:
       actions:
       - READ
@@ -234,6 +246,12 @@ Group:
   name: gp_infield_oid_template_admins
   sourceId: <change_me>
 - capabilities:
+  - groupsAcl:
+      actions:
+      - LIST
+      - READ
+      scope:
+        currentuserscope: {}
   - threedAcl:
       actions:
       - READ
@@ -334,6 +352,12 @@ Group:
   name: gp_infield_oid_viewers
   sourceId: <change_me>
 - capabilities:
+  - groupsAcl:
+      actions:
+      - LIST
+      - READ
+      scope:
+        currentuserscope: {}
   - threedAcl:
       actions:
       - READ


### PR DESCRIPTION
## Description

Ref: https://cognitedata.slack.com/archives/C05RW13C6TX/p1703245850911189

From changelog:

### Fixed

- Fixed bug in `cdf-tk deploy` where auth groups with a mix of all and resource scoped capabilities skipped 
  the all scoped capabilities. This is now fixed.


## Checklist:
- [x] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [x] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped. [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
