### PR TITLE
Use mypy instead of dmypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
   - hooks:
     - id: mypy
       name: mypy
-      entry: dmypy run -- cognite_toolkit/cdf_tk/utils.py cognite_toolkit/cdf_tk/bootstrap.py cognite_toolkit/cdf_tk/dump.py cognite_toolkit/cdf_tk/delete.py
+      entry: mypy cognite_toolkit/cdf_tk/utils.py cognite_toolkit/cdf_tk/bootstrap.py cognite_toolkit/cdf_tk/dump.py cognite_toolkit/cdf_tk/delete.py
       files: ^.*.(py|pyi)$
       language: system
       pass_filenames: false


### PR DESCRIPTION
This pull request updates the build process to use mypy instead of dmypy for type checking. The `mypy` command is now used in the `mypy` hook in the build configuration file. This change ensures consistency and improves the overall build process.