### PR TITLE
fix; TypeError: issubclass() arg 1 must be a class

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,13 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [TBD] - TBD
+
+### Fixed
+
+- Fixed bug in command `cdf-tk build` that can occur when running on `Python>=3.10` which caused an error with text
+  `TypeError: issubclass() arg 1 must be a class`. This is now fixed.
+
 ## [0.1.0b3] - 2024-01-02
 
 ### Fixed

--- a/cognite_toolkit/cdf_tk/utils.py
+++ b/cognite_toolkit/cdf_tk/utils.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import re
+import sys
 import types
 import typing
 from collections import UserList
@@ -649,9 +650,11 @@ def _validate_case_raw(
                 continue
 
             container_type = get_origin(type_hint)
-            if container_type is types.UnionType:
-                args = typing.get_args(type_hint)
-                type_hint = next((arg for arg in args if arg is not type(None)), None)
+            if sys.version_info >= (3, 10):
+                # UnionType was introduced in Python 3.10
+                if container_type is types.UnionType:
+                    args = typing.get_args(type_hint)
+                    type_hint = next((arg for arg in args if arg is not type(None)), None)
 
             mappings = [dict, collections.abc.MutableMapping, collections.abc.Mapping]
             is_mapping = container_type in mappings or (


### PR DESCRIPTION
# Description

Please describe the change you have made.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
