### PR TITLE
[CDF-20672] Consistent YAML file endings.

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -26,6 +26,8 @@ Changes are grouped as follows:
 
 - Fixed bug when calling any command loading a `.env` file and the path is not relative to the current working
   directory. This is now fixed.
+- Fixed all `YAML` files in `cognite_modules` to use `LF` line endings. This is to ensure that `cdf-tk init --upgrade`
+  do not result in diffs due to `CRLF` vs `LF` line endings.
 
 ## [0.1.0b4] - 2024-01-08
 

--- a/tests/change_file_endings.py
+++ b/tests/change_file_endings.py
@@ -1,0 +1,15 @@
+from constants import REPO_ROOT
+
+from cognite_toolkit.cdf_tk.templates import COGNITE_MODULES
+
+
+def main():
+    yaml_files = list((REPO_ROOT / "cognite_toolkit" / COGNITE_MODULES).glob("**/*.yaml"))
+
+    for yaml_file in yaml_files:
+        byte_content = yaml_file.read_bytes()
+        yaml_file.write_bytes(byte_content.replace(b"\r\n", b"\n"))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -9,7 +9,7 @@ import yaml
 from packaging.version import Version
 
 from cognite_toolkit._version import __version__
-from cognite_toolkit.cdf_tk.templates import generate_config
+from cognite_toolkit.cdf_tk.templates import COGNITE_MODULES, generate_config
 from tests.constants import REPO_ROOT
 
 if sys.version_info >= (3, 11):
@@ -93,6 +93,23 @@ def test_environment_system_variables_updated() -> None:
     assert (
         system_variables["cdf_toolkit_version"] == __version__
     ), "The 'cdf_tk_version' system variable is not up to date."
+
+
+def test_all_yaml_files_have_LF_line_endings() -> None:
+    yaml_files = list((REPO_ROOT / "cognite_toolkit" / COGNITE_MODULES).glob("**/*.yaml"))
+
+    wrong_line_endings = []
+    for yaml_file in yaml_files:
+        with open(yaml_file, "rb") as f:
+            content = f.read()
+            if b"\r\n" in content or b"\r" in content:
+                wrong_line_endings.append(yaml_file)
+
+    assert (
+        not wrong_line_endings
+    ), "The following YAML files have CRLF line endings. Please change them to LF:\n" + "\n".join(
+        str(path) for path in wrong_line_endings
+    )
 
 
 def _parse_changelog(changelog: str) -> Iterator[Match[str]]:


### PR DESCRIPTION
# Description
I changed the file endings to all flies as well, but seems that does not show up as diffs in GitHub

## Checklist

- [x] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
