### PR TITLE
ACL scope logic fix

### DIFF
--- a/cognite_toolkit/cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/cdf_tk/load/_resource_loaders.py
@@ -207,7 +207,8 @@ class AuthLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLis
         for capability in raw.get("capabilities", []):
             for acl, values in capability.items():
                 scope = values.get("scope", {})
-                is_resource_scoped = any(scope_name in scope for scope_name in self.resource_scope_names)
+                if not is_resource_scoped:
+                    is_resource_scoped = any(scope_name in scope for scope_name in self.resource_scope_names)
                 if self.target_scopes == "all_scoped_only" and is_resource_scoped:
                     # If a group has a single capability with a resource scope, we skip it.
                     # None indicates skip
@@ -232,7 +233,6 @@ class AuthLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLis
                         ]
 
         if not is_resource_scoped and self.target_scopes == "resource_scoped_only":
-            # If a group has no resource scoped capabilities, we skip it.
             return None
 
         return GroupWrite.load(raw)


### PR DESCRIPTION
# Description

The AuthLoader.load_resource() would deem an entire Group "non-scoped" if the last ACL was not scoped to anything except "all". 
 
## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
