### PR TITLE
[CDF-21023] Bug loading parent variables

### DIFF
--- a/cognite_toolkit/cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/cdf_tk/templates/data_classes/_config_yaml.py
@@ -428,8 +428,8 @@ class InitConfigYAML(YAMLWithComments[tuple[str, ...], ConfigEntry], ConfigYAMLC
                 if key_path in self:
                     continue
                 # Search for the first parent that match.
-                for i in range(len(key_parents) - 1, -1, -1):
-                    alt_key_path = (self._modules, key_parent[0], *key_parent[i - 1 : len(key_parents)], variable)
+                for i in range(1, len(key_parent)):
+                    alt_key_path = (self._modules, *key_parent[:i], variable)
                     if alt_key_path in self:
                         break
                 else:

--- a/cognite_toolkit/cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/cdf_tk/templates/data_classes/_config_yaml.py
@@ -393,7 +393,7 @@ class InitConfigYAML(YAMLWithComments[tuple[str, ...], ConfigEntry], ConfigYAMLC
         Returns:
             self
         """
-        variable_by_paren_key: dict[str, set[tuple[str, ...]]] = defaultdict(set)
+        variable_by_parent_key: dict[str, set[tuple[str, ...]]] = defaultdict(set)
         for filepath in project_dir.glob("**/*"):
             if filepath.suffix.lower() not in SEARCH_VARIABLES_SUFFIX:
                 continue
@@ -405,9 +405,14 @@ class InitConfigYAML(YAMLWithComments[tuple[str, ...], ConfigEntry], ConfigYAMLC
                 key_parent = key_parent[:-1]
 
             for match in re.findall(r"{{\s*([a-zA-Z0-9_]+)\s*}}", content):
-                variable_by_paren_key[match].add(key_parent)
+                variable_by_parent_key[match].add(key_parent)
 
-        for variable, key_parents in variable_by_paren_key.items():
+        return self._load_variables(variable_by_parent_key, propagate_reused_variables)
+
+    def _load_variables(
+        self, variable_by_parent_key: dict[str, set[tuple[str, ...]]], propagate_reused_variables: bool = False
+    ) -> InitConfigYAML:
+        for variable, key_parents in variable_by_parent_key.items():
             if len(key_parents) > 1 and propagate_reused_variables:
                 key_parents = {self._find_common_parent(list(key_parents))}
 

--- a/tests/tests_unit/test_cdf_tk/test_templates.py
+++ b/tests/tests_unit/test_cdf_tk/test_templates.py
@@ -20,6 +20,7 @@ from cognite_toolkit.cdf_tk.templates import (
 )
 from cognite_toolkit.cdf_tk.templates.data_classes import (
     BuildConfigYAML,
+    ConfigEntry,
     Environment,
     InitConfigYAML,
     SystemYAML,
@@ -164,6 +165,22 @@ variable4: "value with #in it" # But a comment after
         extra = set(config.keys()) - expected
         assert not missing, f"Missing keys: {missing}. Got extra {extra}"
         assert not extra, f"Extra keys: {extra}"
+
+    def test_load_parent_variables(self, dummy_environment: Environment) -> None:
+        config = InitConfigYAML(
+            dummy_environment,
+            {
+                ("modules", "cognite_modules", "infield", "shared_variable"): ConfigEntry(
+                    key_path=("modules", "cognite_modules", "infield", "shared_variable"),
+                    default_value="shared_value",
+                )
+            },
+        )
+
+        config._load_variables({"shared_variable": {("cognite_modules", "infield", "cdf_infield_common")}})
+
+        assert ("modules", "cognite_modules", "infield", "shared_variable") in config.keys()
+        assert ("modules", "cognite_modules", "infield", "cdf_infield_common", "shared_variable") not in config.keys()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description
Issue is that when you have a structure such as this:
```bash
📦infield
 ┣ 📂cdf_infield_common
 ┃ ┗ 📜default.config.yaml.
 ┣ 📂cdf_infield_location
 ┃ ┗ 📜default.config.yaml.
 ┗ 📜default.config.yaml.
```
with the top level `default.config.yaml` 
```yaml
shared_variable: shared_value
```

The generated config files becomes
```yaml
    infield:
      cdf_infield_common:
        applicationsconfiguration_source_id: <change_me>

      cdf_infield_location:
        # This default_location points to the location created by the cdf_oid_example_data module.
        # When you create your own location by copying the cdf_oid_example_data module to
        # set up data sets and groups, the below needs to refer to the location to define.
        #
        default_location: oid
        module_version: '1'
        apm_datamodel_space: APM_SourceData
        apm_app_config_external_id: default-infield-config-minimal
        apm_config_instance_space: APM_Config
        # RAW databases to load workorders and other workorder data from
        # The below values point to the RAW database in the cdf_oid_example_data and should be
        # changed if you want to load workorders from another RAW database.
        source_asset: workmate
        source_workorder: workmate
        workorder_raw_db: workorder_oid_workmate
        # The table name in the raw_db database that has workorder data
        workorder_table_name: workorders
        # the root asset for this location, needs to be updated for each location
        root_asset_external_id: WMT:VAL
        # the following properties are required for
        # infield and must be updated for each location
        infield_default_location_checklist_admin_users_source_id: <change_me>
        infield_default_location_normal_users_source_id: <change_me>
        infield_default_location_template_admin_users_source_id: <change_me>
        infield_default_location_viewer_users_source_id: <change_me>



```


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
