### PR TITLE
[CDF-21089] Avoid raising exception if .env is missing

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -21,7 +21,7 @@ Changes are grouped as follows:
 
 - Running the command `cdf-tk auth verify --interactive` without a `.env` would raise a
   `AttributeError: 'CDFToolConfig' object has no attribute '_client'` error. This is now fixed and instead the user
-  get a guided experience to set up the `.env` file.
+  gets a guided experience to set up the `.env` file.
 
 ## [0.1.1] - 2024-03-01
 

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -15,6 +15,14 @@ Changes are grouped as follows:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## TBD
+
+### Fixed
+
+- Running the command `cdf-tk auth verify --interactive` without a `.env` would raise a
+  `AttributeError: 'CDFToolConfig' object has no attribute '_client'` error. This is now fixed and instead the user
+  get a guided experience to set up the `.env` file.
+
 ## [0.1.1] - 2024-03-01
 
 ### Fixed

--- a/cognite_toolkit/_cdf.py
+++ b/cognite_toolkit/_cdf.py
@@ -621,7 +621,7 @@ def auth_verify(
     As a minimum, you need the CDF project name, the CDF cluster, an identity provider token URL, and a service account client ID
     and client secret (or an OAuth2 token set in CDF_TOKEN environment variable).
 
-    Needed capabilites for bootstrapping:
+    Needed capabilities for bootstrapping:
     "projectsAcl": ["LIST", "READ"],
     "groupsAcl": ["LIST", "READ", "CREATE", "UPDATE", "DELETE"]
 

--- a/cognite_toolkit/_cdf_tk/bootstrap.py
+++ b/cognite_toolkit/_cdf_tk/bootstrap.py
@@ -210,10 +210,11 @@ def check_auth(
         print(auth_vars.info)
         ToolGlobals.failed = True
         return None
-    if auth_vars.warning:
+    elif auth_vars.warning:
         print(auth_vars.info)
     else:
         print("  [bold green]OK[/]")
+    ToolGlobals.reinitialize_from_auth_variables(auth_vars)
     print("Checking basic project configuration...")
     try:
         # Using the token/inspect endpoint to check if the client has access to the project.

--- a/cognite_toolkit/_cdf_tk/bootstrap.py
+++ b/cognite_toolkit/_cdf_tk/bootstrap.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
@@ -28,25 +27,7 @@ from rich.markup import escape
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
-from .utils import CDFToolConfig
-
-
-@dataclass
-class AuthVariables:
-    cluster: str | None
-    project: str | None
-    token: str | None
-    client_id: str | None
-    client_secret: str | None
-    cdf_url: str | None = None
-    token_url: str | None = None
-    tenant_id: str | None = None
-    audience: str | None = None
-    scopes: str | None = None
-    ok: bool = False
-    info: str = ""
-    error: bool = False
-    warning: bool = False
+from .utils import AuthVariables, CDFToolConfig
 
 
 def get_auth_variables(interactive: bool = False, verbose: bool = False) -> AuthVariables:

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -218,13 +218,11 @@ class CDFToolConfig:
                 self._scopes = [auth.scopes]
             if auth.audience:
                 self._audience = auth.audience
-            if auth.token_url is None or auth.client_id is None or auth.client_secret is None:
-                raise ValueError("Missing required OAuth2 client credentials.")
 
             self.oauth_credentials = OAuthClientCredentials(
-                token_url=auth.token_url,
-                client_id=auth.client_id,
-                client_secret=auth.client_secret,
+                token_url=auth.token_url or self.oauth_credentials.token_url,
+                client_id=auth.client_id or self.oauth_credentials.client_id,
+                client_secret=auth.client_secret or self.oauth_credentials.client_secret,
                 scopes=self._scopes,
                 audience=self._audience,
             )

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -53,6 +53,24 @@ from cognite_toolkit._version import __version__
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class AuthVariables:
+    cluster: str | None
+    project: str | None
+    token: str | None
+    client_id: str | None
+    client_secret: str | None
+    cdf_url: str | None = None
+    token_url: str | None = None
+    tenant_id: str | None = None
+    audience: str | None = None
+    scopes: str | None = None
+    ok: bool = False
+    info: str = ""
+    error: bool = False
+    warning: bool = False
+
+
 class CDFToolConfig:
     """Configurations for how to store data in CDF
 

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -102,9 +102,10 @@ class CDFToolConfig:
                 print(
                     "[bold yellow]WARNING[/] Not able to successfully configure a Cognite client. Requirements: CDF_CLUSTER and CDF_PROJECT environment variables or CDF_TOKEN to a valid OAuth2 token."
                 )
-            self._cluster = self._client.config.base_url.removeprefix("https://").split(".", maxsplit=1)[0]
-            self._project = self._client.config.project
-            self._cdf_url = self._client.config.base_url
+            else:
+                self._cluster = self._client.config.base_url.removeprefix("https://").split(".", maxsplit=1)[0]
+                self._project = self._client.config.project
+                self._cdf_url = self._client.config.base_url
             return
 
         # CDF_CLUSTER and CDF_PROJECT are minimum requirements to know where to connect.


### PR DESCRIPTION
# Description

## Bug 1
Problem if there is no `.env` present and you want to use `cdf-tk auth verify --interactive` the following exception is raised:

```bash

cdf-tk auth verify --interactive
WARNING: No .env file found in current or parent directory.
WARNING Not able to successfully configure a Cognite client. Requirements: CDF_CLUSTER and CDF_PROJECT environment variables or CDF_TOKEN to a valid OAuth2 token.
Traceback (most recent call last):
...
  File "C:\Users\AndersAlbert\Projects\internal\cdf-project-templates\cognite_toolkit\_cdf.py", line 633, in auth_verify
    ToolGlobals = CDFToolConfig.from_context(ctx)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\AndersAlbert\Projects\internal\cdf-project-templates\cognite_toolkit\_cdf_tk\utils.py", line 163, in from_context
    return CDFToolConfig(cluster=ctx.obj.cluster, project=ctx.obj.project)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\AndersAlbert\Projects\internal\cdf-project-templates\cognite_toolkit\_cdf_tk\utils.py", line 105, in __init__
    self._cluster = self._client.config.base_url.removeprefix("https://").split(".", maxsplit=1)[0]
                    ^^^^^^^^^^^^
AttributeError: 'CDFToolConfig' object has no attribute '_client'. Did you mean: 'client'?
```

## Bug 2
This triggered a second bug. After inputting valid credentials you get this error:
```bash
Checking basic project configuration...
  ERROR: Not a valid authentication token. Check credentials (CDF_CLIENT_ID/CDF_CLIENT_SECRET or CDF_TOKEN).
ERROR:  Failure to verify access rights.
```
This is also fixed. 


## Tests:
This is manually tested as interactive flows are trickier to test with regular python tests
## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
