### PR TITLE
[Prep for CDF-21163] Refactor CDFToolConfig

### DIFF
--- a/cognite_toolkit/_cdf_tk/load/_data_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_data_loaders.py
@@ -27,11 +27,7 @@ class DatapointsLoader(DataLoader):
 
     @classmethod
     def get_required_capability(cls, ToolGlobals: CDFToolConfig) -> Capability:
-        scope: capabilities.AllScope | capabilities.DataSetScope = (
-            TimeSeriesAcl.Scope.DataSet([ToolGlobals.data_set_id])
-            if ToolGlobals.data_set_id
-            else TimeSeriesAcl.Scope.All()
-        )
+        scope: capabilities.AllScope | capabilities.DataSetScope = TimeSeriesAcl.Scope.All()
 
         return TimeSeriesAcl(
             [TimeSeriesAcl.Action.Read, TimeSeriesAcl.Action.Write],
@@ -89,10 +85,7 @@ class FileLoader(DataLoader):
     @classmethod
     def get_required_capability(cls, ToolGlobals: CDFToolConfig) -> Capability | list[Capability]:
         scope: capabilities.AllScope | capabilities.DataSetScope
-        if ToolGlobals.data_set_id is None:
-            scope = FilesAcl.Scope.All()
-        else:
-            scope = FilesAcl.Scope.DataSet([ToolGlobals.data_set_id])
+        scope = FilesAcl.Scope.All()
 
         return FilesAcl([FilesAcl.Action.Read, FilesAcl.Action.Write], scope)
 

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -913,11 +913,7 @@ class TimeSeriesLoader(ResourceContainerLoader[str, TimeSeriesWrite, TimeSeries,
     def get_required_capability(cls, ToolGlobals: CDFToolConfig) -> Capability:
         return TimeSeriesAcl(
             [TimeSeriesAcl.Action.Read, TimeSeriesAcl.Action.Write],
-            (
-                TimeSeriesAcl.Scope.DataSet([ToolGlobals.data_set_id])
-                if ToolGlobals.data_set_id
-                else TimeSeriesAcl.Scope.All()
-            ),
+            TimeSeriesAcl.Scope.All(),
         )
 
     @classmethod
@@ -993,11 +989,7 @@ class TransformationLoader(
 
     @classmethod
     def get_required_capability(cls, ToolGlobals: CDFToolConfig) -> Capability:
-        scope: capabilities.AllScope | capabilities.DataSetScope = (
-            TransformationsAcl.Scope.DataSet([ToolGlobals.data_set_id])
-            if ToolGlobals.data_set_id
-            else TransformationsAcl.Scope.All()
-        )
+        scope: capabilities.AllScope | capabilities.DataSetScope = TransformationsAcl.Scope.All()
         return TransformationsAcl(
             [TransformationsAcl.Action.Read, TransformationsAcl.Action.Write],
             scope,
@@ -1105,11 +1097,7 @@ class TransformationScheduleLoader(
 
     @classmethod
     def get_required_capability(cls, ToolGlobals: CDFToolConfig) -> Capability:
-        scope: capabilities.AllScope | capabilities.DataSetScope = (
-            TransformationsAcl.Scope.DataSet([ToolGlobals.data_set_id])
-            if ToolGlobals.data_set_id
-            else TransformationsAcl.Scope.All()
-        )
+        scope: capabilities.AllScope | capabilities.DataSetScope = TransformationsAcl.Scope.All()
         return TransformationsAcl(
             [TransformationsAcl.Action.Read, TransformationsAcl.Action.Write],
             scope,
@@ -1342,10 +1330,7 @@ class FileMetadataLoader(
     @classmethod
     def get_required_capability(cls, ToolGlobals: CDFToolConfig) -> Capability:
         scope: capabilities.AllScope | capabilities.DataSetScope
-        if ToolGlobals.data_set_id is None:
-            scope = FilesAcl.Scope.All()
-        else:
-            scope = FilesAcl.Scope.DataSet([ToolGlobals.data_set_id])
+        scope = FilesAcl.Scope.All()
 
         return FilesAcl([FilesAcl.Action.Read, FilesAcl.Action.Write], scope)
 

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -205,12 +205,16 @@ class CDFToolConfig:
                 )
             )
         else:
+            if not (auth.token_url and auth.client_id and auth.client_secret):
+                print(
+                    "  [bold yellow]Warning[/] Missing required authentication variables. Cannot reinitialize client."
+                )
+                return
+
             if auth.scopes:
                 self._scopes = [auth.scopes]
             if auth.audience:
                 self._audience = auth.audience
-            if not (auth.token_url and auth.client_id and auth.client_secret):
-                raise ValueError("Token URL, client id, and client secret must be set to initialize a CogniteClient")
             oauth_credentials = OAuthClientCredentials(
                 token_url=auth.token_url,
                 client_id=auth.client_id,

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -37,7 +37,7 @@ import typer
 import yaml
 from cognite.client import ClientConfig, CogniteClient
 from cognite.client.config import global_config
-from cognite.client.credentials import OAuthClientCredentials, Token
+from cognite.client.credentials import CredentialProvider, OAuthClientCredentials, Token
 from cognite.client.data_classes import CreatedSession
 from cognite.client.data_classes._base import CogniteObject
 from cognite.client.data_classes.capabilities import Capability
@@ -92,6 +92,15 @@ class CDFToolConfig:
         self._cache = self._Cache()
         self._failed = False
         self._environ: dict[str, str | None] = {}
+        # If cluster, project, or token are passed as arguments, we override the environment variables.
+        # This means these will be used when we initialize the CogniteClient when we initialize from
+        # environment variables. Note if we are running in the browser, we will not use these arguments.
+        if project:
+            self._environ["CDF_PROJECT"] = project
+        if cluster:
+            self._environ["CDF_CLUSTER"] = cluster
+        if token:
+            self._environ["CDF_TOKEN"] = token
 
         # ClientName is used for logging usage of the CDF-Toolkit.
         self._client_name = f"CDF-Toolkit:{__version__}"
@@ -107,14 +116,8 @@ class CDFToolConfig:
             self._initialize_in_browser()
             return
 
-        self.oauth_credentials = OAuthClientCredentials(
-            token_url="",
-            client_id="",
-            client_secret="",
-            scopes=[],
-        )
-
-        self._initialize_from_environment_variables(cluster=cluster, project=project, token=token)
+        self._initialize_from_environment_variables()
+        global_config.disable_pypi_version_check = True
 
     def _initialize_in_browser(self) -> None:
         try:
@@ -122,43 +125,31 @@ class CDFToolConfig:
         except Exception as e:
             print(f"[bold red]Error[/] Failed to initialize CogniteClient in browser: {e}")
         else:
+            if self._cluster or self._project:
+                print("[bold yellow]Warning[/] Cluster and project are arguments ignored when running in the browser.")
             self._cluster = self._client.config.base_url.removeprefix("https://").split(".", maxsplit=1)[0]
             self._project = self._client.config.project
             self._cdf_url = self._client.config.base_url
 
-    def _initialize_from_environment_variables(
-        self, cluster: str | None = None, project: str | None = None, token: str | None = None
-    ) -> None:
-        # CDF_CLUSTER and CDF_PROJECT are minimum requirements and can be overridden
-        # when instantiating the class.
-        if cluster is not None and len(cluster) > 0:
-            self._cluster = cluster
-            self._environ["CDF_CLUSTER"] = cluster
+    def _initialize_from_environment_variables(self) -> None:
+        # CDF_CLUSTER and CDF_PROJECT are minimum requirements.
+        # We check that whether we miss any of them, so we can give a better error message.
 
-        if project is not None and len(project) > 0:
-            self._project = project
-            self._environ["CDF_PROJECT"] = project
+        missing = {key: self.environ(key, fail=False) for key in ["CDF_CLUSTER", "CDF_PROJECT"]}
+        if any(value is None for value in missing.values()):
+            raise ValueError(
+                f"The environment variables {list(missing)} are required. Missing: {[key for key, value in missing.items() if value is None]}"
+            )
 
-        if token is not None:
-            self._environ["CDF_TOKEN"] = token
-
-        # CDF_CLUSTER and CDF_PROJECT are minimum requirements to know where to connect.
-        # Above they were forced default to None and fail was False, here we
-        # will fail with an exception if they are not set.
         self._cluster = self.environ("CDF_CLUSTER")
         self._project = self.environ("CDF_PROJECT")
         # CDF_URL is optional, but if set, we use that instead of the default URL using cluster.
         self._cdf_url = self.environ("CDF_URL", f"https://{self._cluster}.cognitedata.com")
+
+        credentials_provider: CredentialProvider
         # If CDF_TOKEN is set, we want to use that token instead of client credentials.
-        if self.environ("CDF_TOKEN", default=None, fail=False) is not None or token is not None:
-            self._client = CogniteClient(
-                ClientConfig(
-                    client_name=self._client_name,
-                    base_url=self._cdf_url,
-                    project=self._project,
-                    credentials=Token(token or self.environ("CDF_TOKEN")),
-                )
-            )
+        if (token := self.environ("CDF_TOKEN", fail=False)) is not None:
+            credentials_provider = Token(token)
         else:
             # We are now doing OAuth2 client credentials flow, so we need to set the
             # required variables.
@@ -172,7 +163,7 @@ class CDFToolConfig:
                 )
             ]
             self._audience = self.environ("IDP_AUDIENCE", f"https://{self._cluster}.cognitedata.com")
-            self.oauth_credentials = OAuthClientCredentials(
+            credentials_provider = OAuthClientCredentials(
                 token_url=self.environ("IDP_TOKEN_URL"),
                 client_id=self.environ("IDP_CLIENT_ID"),
                 # client secret should not be stored in-code, so we load it from an environment variable
@@ -180,15 +171,15 @@ class CDFToolConfig:
                 scopes=self._scopes,
                 audience=self._audience,
             )
-            global_config.disable_pypi_version_check = True
-            self._client = CogniteClient(
-                ClientConfig(
-                    client_name=self._client_name,
-                    base_url=self._cdf_url,
-                    project=self._project,
-                    credentials=self.oauth_credentials,
-                )
+
+        self._client = CogniteClient(
+            ClientConfig(
+                client_name=self._client_name,
+                base_url=self._cdf_url,
+                project=self._project,
+                credentials=credentials_provider,
             )
+        )
 
     def reinitialize_from_auth_variables(self, auth: AuthVariables) -> None:
         if auth.cluster:
@@ -218,11 +209,12 @@ class CDFToolConfig:
                 self._scopes = [auth.scopes]
             if auth.audience:
                 self._audience = auth.audience
-
-            self.oauth_credentials = OAuthClientCredentials(
-                token_url=auth.token_url or self.oauth_credentials.token_url,
-                client_id=auth.client_id or self.oauth_credentials.client_id,
-                client_secret=auth.client_secret or self.oauth_credentials.client_secret,
+            if not (auth.token_url and auth.client_id and auth.client_secret):
+                raise ValueError("Token URL, client id, and client secret must be set to initialize a CogniteClient")
+            oauth_credentials = OAuthClientCredentials(
+                token_url=auth.token_url,
+                client_id=auth.client_id,
+                client_secret=auth.client_secret,
                 scopes=self._scopes,
                 audience=self._audience,
             )
@@ -231,7 +223,7 @@ class CDFToolConfig:
                     client_name=self._client_name,
                     base_url=self._cdf_url,
                     project=self._project,
-                    credentials=self.oauth_credentials,
+                    credentials=oauth_credentials,
                 )
             )
 

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -89,8 +89,6 @@ class CDFToolConfig:
 
     def __init__(self, token: str | None = None, cluster: str | None = None, project: str | None = None) -> None:
         self._cache = self._Cache()
-        self._data_set_id: int = 0
-        self._data_set: str | None = None
         self._failed = False
         self._environ: dict[str, str | None] = {}
 
@@ -293,15 +291,6 @@ class CDFToolConfig:
             raise ValueError("Project is not initialized.")
         return self._project
 
-    @property
-    def data_set_id(self) -> int | None:
-        return self._data_set_id if self._data_set_id > 0 else None
-
-    # Use this to ignore the data set when verifying the client's access capabilities
-    def clear_dataset(self) -> None:
-        self._data_set_id = 0
-        self._data_set = None
-
     @overload
     def environ(self, attr: str, default: str | None = None, fail: Literal[True] = True) -> str: ...
 
@@ -339,18 +328,6 @@ class CDFToolConfig:
 
         self._environ[attr] = var
         return var
-
-    @property
-    def data_set(self) -> str | None:
-        return self._data_set
-
-    @data_set.setter
-    def data_set(self, value: str) -> None:
-        if value is None:
-            raise ValueError("Please provide an externalId of a dataset.")
-        self._data_set = value
-        # Since we now have a new configuration, check the dataset and set the id
-        self._data_set_id = self.verify_dataset(data_set_external_id=value)
 
     def verify_client(
         self,

--- a/tests/tests_unit/test_api/conftest.py
+++ b/tests/tests_unit/test_api/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from cognite_toolkit._api import CogniteToolkit
@@ -5,7 +7,34 @@ from tests.tests_unit.approval_client import ApprovalCogniteClient
 
 
 @pytest.fixture
-def cognite_toolkit(cognite_client_approval: ApprovalCogniteClient) -> CogniteToolkit:
+def set_environment_variables() -> None:
+    environment_variables = {
+        "CDF_PROJECT": "pytest-project",
+        "CDF_CLUSTER": "bluefield",
+        "IDP_TOKEN_URL": "dummy",
+        "IDP_CLIENT_ID": "dummy",
+        "IDP_CLIENT_SECRET": "dummy",
+        "IDP_TENANT_ID": "dummy",
+        "IDP_AUDIENCE": "https://bluefield.cognitedata.com",
+        "IDP_SCOPES": "https://bluefield.cognitedata.com/.default",
+        "CDF_URL": "https://bluefield.cognitedata.com",
+    }
+    existing = {}
+    for key, value in environment_variables.items():
+        existing[key] = os.environ.get(key)
+        os.environ[key] = value
+
+    yield None
+
+    for key, value in existing.items():
+        if value is None:
+            del os.environ[key]
+        else:
+            os.environ[key] = value
+
+
+@pytest.fixture
+def cognite_toolkit(cognite_client_approval: ApprovalCogniteClient, set_environment_variables: None) -> CogniteToolkit:
     toolkit = CogniteToolkit()
     toolkit.client = cognite_client_approval.client
     return toolkit

--- a/tests/tests_unit/test_cdf_tk/test_utils.py
+++ b/tests/tests_unit/test_cdf_tk/test_utils.py
@@ -38,7 +38,7 @@ DATA_FOLDER = THIS_FOLDER / "load_data"
 
 def mocked_init(self):
     self._client = CogniteClientMock()
-    self._client._cache = CDFToolConfig._Cache()
+    self._cache = CDFToolConfig._Cache()
 
 
 def test_init():

--- a/tests/tests_unit/test_cdf_tk/test_utils.py
+++ b/tests/tests_unit/test_cdf_tk/test_utils.py
@@ -38,7 +38,7 @@ DATA_FOLDER = THIS_FOLDER / "load_data"
 
 def mocked_init(self):
     self._client = CogniteClientMock()
-    self._data_set_id_by_external_id = {}
+    self._client._cache = CDFToolConfig._Cache()
 
 
 def test_init():


### PR DESCRIPTION
# Description
Refactoring to prepare for supporting interactive loginflow

Changes:
* Moved out `existing_spaces` and `data_set_id_by_external_id` to a `_cache` variable to make the functions of these clear.
* Removed `_data_set_id` and `_data_set`. They turned out to never be set, thus it is misleading in the ResourceLoaders that they are scoped to a DataSet in the `get_required_capability` call. That will never happen. So I removed them. I think we need to think a bit more about how to setup the toolkit to deal with resource scoped access.
* Refactored the initialization of the client to make it clearer what is going on. 

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
