### PR TITLE
ci: threshold on action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,7 @@ jobs:
         uses: orgoro/coverage@v3.1
         with:
             coverageFile: coverage.xml
+            thresholdAll: 0.6
             token: ${{ secrets.GITHUB_TOKEN }}
   dry-run-demo:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ pytest-cov = "^4.1.0"
 cdf-tk = "cognite_toolkit._cdf:app"
 
 [tool.coverage.report]
-fail_under = 60
 show_missing = true
 
 [tool.mypy]


### PR DESCRIPTION
# Description
Now the GitHub action step for creating the report will fail instead of the running the test step if the coverage falls bellow threshold.

Advantage: Threshold is shown in report, and report is shown also when the coverage test falls. 

![image](https://github.com/cognitedata/cdf-project-templates/assets/60234212/794c8beb-e05d-4397-90c9-b015be837967)


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
