### PR TITLE
Replace black with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,19 +12,10 @@ repos:
           - --select=E,W,F,I,T,RUF,TID,UP
           - --fixable=E,W,F,I,T,RUF,TID,UP
           - --target-version=py39
-    rev: v0.3.5
-
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
-    hooks:
-      - id: black
+      - id: ruff-format
         args:
           - --line-length=120
-          - --target-version=py38
-          - --target-version=py39
-          - --target-version=py310
-          - --target-version=py311
-          - --include=\.py$
+    rev: v0.3.5
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/cdf-tk-dev.py
+++ b/cdf-tk-dev.py
@@ -6,23 +6,23 @@
 # However, when you run the file in Visual Studio Code, the module should not be installed in your
 # python virtual environment, but rather be found in the root of the repo.
 # This workaround allows you to run cdf.py in Visual Studio Code like this:
-"""         {
-            "name": "Python: build",
-            "type": "python",
-            "request": "launch",
-            "program": "./cdf-tk-dev.py",
-            "args": [
-                "--verbose",
-                "--override-env",
-                "build",
-                "--build-dir=build",
-                "--clean",
-                "--env=local",
-                "./cognite_toolkit/"
-            ],
-            "console": "integratedTerminal",
-            "justMyCode": false
-        },
+"""{
+    "name": "Python: build",
+    "type": "python",
+    "request": "launch",
+    "program": "./cdf-tk-dev.py",
+    "args": [
+        "--verbose",
+        "--override-env",
+        "build",
+        "--build-dir=build",
+        "--clean",
+        "--env=local",
+        "./cognite_toolkit/"
+    ],
+    "console": "integratedTerminal",
+    "justMyCode": false
+},
 """
 
 import os

--- a/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_resource_loaders.py
@@ -231,7 +231,6 @@ class AuthLoader(ResourceLoader[str, GroupWrite, Group, GroupWriteList, GroupLis
             raw = [raw]
 
         for group in raw:
-
             is_resource_scoped = any(
                 any(scope_name in capability.get(acl, {}).get("scope", {}) for scope_name in self.resource_scope_names)
                 for capability in group.get("capabilities", [])
@@ -1014,7 +1013,6 @@ class TransformationLoader(
         transformations = TransformationWriteList([])
 
         for resource in resources:
-
             source_oidc_credentials = (
                 resource.get("authentication", {}).get("read") or resource.get("authentication") or None
             )

--- a/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_files_valhall/functions/fn_context_files_oid_fileshare_annotation/pipeline.py
+++ b/cognite_toolkit/cognite_modules/examples/cdf_data_pipeline_files_valhall/functions/fn_context_files_oid_fileshare_annotation/pipeline.py
@@ -83,7 +83,6 @@ def annotate_pnid(client: CogniteClient, config: AnnotationConfig) -> None:
 
             # if no files to annotate - continue to next asset
             if len(files_to_process) > 0:
-
                 entities = get_files_entities(all_files)
                 annotation_list = get_existing_annotations(client, entities) if entities else {}
 
@@ -353,7 +352,6 @@ def process_files(
                 asset_ids_list = asset_ids_list[:1000]
 
             if config.debug:
-
                 print(f"[INFO] Assets found: {asset_names}")
                 continue
 
@@ -413,7 +411,6 @@ def detect_create_annotation(
 
     detected_system_num, detected_count = get_sys_nums(job.result["items"][0]["annotations"], detected_count)
     for item in job.result["items"][0]["annotations"]:
-
         textRegion = get_coordinates(item["region"]["vertices"])
 
         for entity in item["entities"]:

--- a/tests/tests_unit/test_approval_modules_snapshots/cdf_data_pipeline_files_valhall.yaml
+++ b/tests/tests_unit/test_approval_modules_snapshots/cdf_data_pipeline_files_valhall.yaml
@@ -76,7 +76,7 @@ Function:
   externalId: fn_context_files_oid_fileshare_annotation
   functionPath: handler.py
   metadata:
-    cdf-toolkit-function-hash: 2cc9704f01bac8c7f6fa17f7fc916747431253398cb71a312e53c1d3163bf375
+    cdf-toolkit-function-hash: c5fddc5cb0ccfcac02205cfb3eccfef878e73a75762671ebc6bfeb050e6dc86e
     version: 0.0.1
   name: context:files:oid:fileshare:annotation
   owner: Anonymous

--- a/tests/tests_unit/test_cdf_tk/test_load.py
+++ b/tests/tests_unit/test_cdf_tk/test_load.py
@@ -74,9 +74,7 @@ def test_loader_class(
 
 
 class TestFunctionLoader:
-
     def test_load_functions(self, cognite_client_approval: ApprovalCogniteClient):
-
         cdf_tool = MagicMock(spec=CDFToolConfig)
         cdf_tool.verify_client.return_value = cognite_client_approval.mock_client
         cdf_tool.verify_capabilities.return_value = cognite_client_approval.mock_client
@@ -88,7 +86,6 @@ class TestFunctionLoader:
         assert len(loaded) == 2
 
     def test_load_function(self, cognite_client_approval: ApprovalCogniteClient):
-
         cdf_tool = MagicMock(spec=CDFToolConfig)
         cdf_tool.verify_client.return_value = cognite_client_approval.mock_client
         cdf_tool.verify_capabilities.return_value = cognite_client_approval.mock_client
@@ -231,9 +228,7 @@ class TestDataModelLoader:
 
 
 class TestAuthLoader:
-
     def test_load_all(self, cdf_tool_config: CDFToolConfig, monkeypatch: MonkeyPatch):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "all")
 
         loaded = loader.load_resource(
@@ -254,7 +249,6 @@ class TestAuthLoader:
         assert caps["SessionsAcl"].scope._scope_name == "all"
 
     def test_load_all_scoped_only(self, cdf_tool_config: CDFToolConfig, monkeypatch: MonkeyPatch):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "all_scoped_only")
         loaded = loader.load_resource(
             DATA_FOLDER / "auth" / "1.my_group_unscoped.yaml", cdf_tool_config, skip_validation=False
@@ -267,7 +261,6 @@ class TestAuthLoader:
         assert loaded is None
 
     def test_load_resource_scoped_only(self, cdf_tool_config: CDFToolConfig, monkeypatch: MonkeyPatch):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "resource_scoped_only")
         loaded = loader.load_resource(
             DATA_FOLDER / "auth" / "1.my_group_unscoped.yaml", cdf_tool_config, skip_validation=False
@@ -289,7 +282,6 @@ class TestAuthLoader:
         assert caps["SessionsAcl"].scope._scope_name == "all"
 
     def test_load_group_list_all(self, cdf_tool_config: CDFToolConfig, monkeypatch: MonkeyPatch):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "all")
         loaded = loader.load_resource(
             DATA_FOLDER / "auth" / "1.my_group_list_combined.yaml", cdf_tool_config, skip_validation=True
@@ -299,7 +291,6 @@ class TestAuthLoader:
         assert len(loaded) == 2
 
     def test_load_group_list_resource_scoped_only(self, cdf_tool_config: CDFToolConfig, monkeypatch: MonkeyPatch):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "resource_scoped_only")
         loaded = loader.load_resource(
             DATA_FOLDER / "auth" / "1.my_group_list_combined.yaml", cdf_tool_config, skip_validation=True
@@ -309,7 +300,6 @@ class TestAuthLoader:
         assert loaded.name == "scoped_group_name"
 
     def test_load_group_list_all_scoped_only(self, cdf_tool_config: CDFToolConfig, monkeypatch: MonkeyPatch):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "all_scoped_only")
         loaded = loader.load_resource(
             DATA_FOLDER / "auth" / "1.my_group_list_combined.yaml", cdf_tool_config, skip_validation=True
@@ -321,7 +311,6 @@ class TestAuthLoader:
     def test_unchanged_new_group(
         self, cdf_tool_config: CDFToolConfig, cognite_client_approval: ApprovalCogniteClient, monkeypatch: MonkeyPatch
     ):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "all")
         loaded = loader.load_resource(
             DATA_FOLDER / "auth" / "1.my_group_scoped.yaml", cdf_tool_config, skip_validation=True
@@ -353,7 +342,6 @@ class TestAuthLoader:
     def test_upsert_group(
         self, cdf_tool_config: CDFToolConfig, cognite_client_approval: ApprovalCogniteClient, monkeypatch: MonkeyPatch
     ):
-
         loader = AuthLoader.create_loader(cdf_tool_config, "all")
         loaded = loader.load_resource(
             DATA_FOLDER / "auth" / "1.my_group_scoped.yaml", cdf_tool_config, skip_validation=True
@@ -503,7 +491,6 @@ class TestListDictConsistency:
     def test_loader_takes_list(
         self, Loader: type[ResourceLoader], cdf_tool_config: CDFToolConfig, monkeypatch: MonkeyPatch
     ):
-
         loader = Loader.create_loader(cdf_tool_config)
 
         if loader.resource_cls in [Transformation, FileMetadata]:

--- a/tests/tests_unit/test_cdf_tk/test_utils.py
+++ b/tests/tests_unit/test_cdf_tk/test_utils.py
@@ -406,7 +406,6 @@ class TestAuthVariables:
         expected_messages: list[str],
         expected_vars: dict[str, str],
     ) -> None:
-
         with mock.patch.dict(os.environ, environment_variables, clear=True):
             auth_var = AuthVariables.from_env()
             results = auth_var.validate(verbose)


### PR DESCRIPTION
# Description

Why? 
* One less dependency to maintain.
* Ruff written in Rust much much faster to run than black.

Ruff-format is almost 1-1 with black.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
