### PR TITLE
[CDF-21405] Modules selected by path

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -20,6 +20,10 @@ Changes are grouped as follows:
 ### Added
 
 - Support for the Workflow and WorkflowVersion resource type
+- Support for specifying `selected_modules_and_packages` as paths and parent paths. For example, you can
+  now write `cognite_modules/core/cdf_apm_base` instead of just `cdf_apm_base`. This is to support
+  modules that have the same name but are in different parent directories. In addition, this also better reflects
+  the structure of the `cognite_modules` and `custom_modules` folder.
 
 ### Fixed
 

--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -23,7 +23,7 @@ Changes are grouped as follows:
 - Support for specifying `selected_modules_and_packages` as paths and parent paths. For example, you can
   now write `cognite_modules/core/cdf_apm_base` instead of just `cdf_apm_base`. This is to support
   modules that have the same name but are in different parent directories. In addition, this also better reflects
-  the structure of the `cognite_modules` and `custom_modules` folder.
+  the structure of the `cognite_modules` and `custom_modules` folder better.
 
 ### Fixed
 

--- a/cognite_toolkit/_cdf_tk/templates/_constants.py
+++ b/cognite_toolkit/_cdf_tk/templates/_constants.py
@@ -14,6 +14,7 @@ CUSTOM_MODULES = "custom_modules"
 ALT_CUSTOM_MODULES = "modules"
 
 ROOT_MODULES = [COGNITE_MODULES, CUSTOM_MODULES, ALT_CUSTOM_MODULES]
+MODULE_PATH_SEP = "/"
 
 # Add any other files below that should be included in a build
 EXCL_FILES = ["README.md", DEFAULT_CONFIG_FILE]

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -626,11 +626,10 @@ def validate(content: str, destination: Path, source_path: Path, modules_by_vari
         if modules := modules_by_variable.get(variable):
             module_str = f"{modules[0]!r}" if len(modules) == 1 else (", ".join(modules[:-1]) + f" or {modules[-1]}")
             print(
-                f"    [bold green]Hint:[/] The variables in 'config.[ENV].yaml' are defined in a tree structure, i.e., "
-                "variables defined at a higher level can be used in lower levels."
-                f"\n    The variable {variable!r} is defined in the following module{'s' if len(modules) > 1 else ''}: {module_str}."
-                f"\n    It needs to be moved up in the config structure to be used"
-                f"in {module!r}."
+                f"    [bold green]Hint:[/] The variables in 'config.[ENV].yaml' need to be organised in a tree structure following"
+                f"\n    the folder structure of the template modules, but can also be moved up the config hierarchy to be shared between modules."
+                f"\n    The variable {variable!r} is defined in the variable section{'s' if len(modules) > 1 else ''} {module_str}."
+                f"\n    Check that {'these paths reflect' if len(modules) > 1 else 'this path reflects'} the location of {module}."
             )
 
     if destination.suffix in {".yaml", ".yml"}:

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -69,7 +69,8 @@ def build_config(
     }:
         print(f"  [bold red]ERROR:[/] Ambiguous module selected in config.{config.environment.name}.yaml:")
         for module_name, paths in duplicate_modules.items():
-            print(f"    {module_name} exists in {[MODULE_PATH_SEP.join(path) for path in paths]}")
+            locations = "\t\t\n".join([MODULE_PATH_SEP.join(path) for path in paths])
+            print(f"    {module_name} exists in:\n{locations}")
         print(
             "    You can use the path syntax to disambiguate between modules with the same name. For example "
             "'cognite_modules/core/cdf_apm_base' instead of 'cdf_apm_base'."

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -447,10 +447,12 @@ def process_config_files(
     number_by_resource_type: dict[str, int] = defaultdict(int)
 
     for module_dir, filepaths in iterate_modules(project_config_dir):
-        if (
-            module_dir.name not in selected_modules
-            and module_dir.relative_to(project_config_dir).parts not in selected_modules
-        ):
+        module_parts = module_dir.relative_to(project_config_dir).parts
+        is_in_selected_modules = module_dir.name in selected_modules or module_parts in selected_modules
+        is_parent_in_selected_modules = any(
+            parent in selected_modules for parent in (module_parts[:i] for i in range(1, len(module_parts)))
+        )
+        if not is_in_selected_modules and not is_parent_in_selected_modules:
             continue
         if verbose:
             print(f"  [bold green]INFO:[/] Processing module {module_dir.name}")

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -443,7 +443,10 @@ def process_config_files(
     number_by_resource_type: dict[str, int] = defaultdict(int)
 
     for module_dir, filepaths in iterate_modules(project_config_dir):
-        if module_dir.name not in selected_modules:
+        if (
+            module_dir.name not in selected_modules
+            and module_dir.relative_to(project_config_dir).parts not in selected_modules
+        ):
             continue
         if verbose:
             print(f"  [bold green]INFO:[/] Processing module {module_dir.name}")

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -56,7 +56,7 @@ def build_config(
 
     config.validate_environment()
 
-    module_name_by_path: dict[str, list[tuple[str]]] = defaultdict(list)
+    module_name_by_path: dict[str, list[tuple[str, ...]]] = defaultdict(list)
     for module, _ in iterate_modules(source_dir):
         module_name_by_path[module.name].append(module.relative_to(source_dir).parts)
     if duplicate_modules := {
@@ -427,7 +427,7 @@ def process_files_directory(
 
 def process_config_files(
     project_config_dir: Path,
-    selected_modules: list[str],
+    selected_modules: list[str | tuple[str, ...]],
     build_dir: Path,
     config: BuildConfigYAML,
     verbose: bool = False,

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -69,8 +69,8 @@ def build_config(
     }:
         print(f"  [bold red]ERROR:[/] Ambiguous module selected in config.{config.environment.name}.yaml:")
         for module_name, paths in duplicate_modules.items():
-            locations = "\t\t\n".join([MODULE_PATH_SEP.join(path) for path in paths])
-            print(f"    {module_name} exists in:\n{locations}")
+            locations = "\n        ".join([MODULE_PATH_SEP.join(path) for path in paths])
+            print(f"    {module_name} exists in:\n        {locations}")
         print(
             "    You can use the path syntax to disambiguate between modules with the same name. For example "
             "'cognite_modules/core/cdf_apm_base' instead of 'cdf_apm_base'."

--- a/cognite_toolkit/_cdf_tk/templates/_templates.py
+++ b/cognite_toolkit/_cdf_tk/templates/_templates.py
@@ -71,7 +71,11 @@ def build_config(
         )
         exit(1)
 
-    available_modules = set(module_name_by_path.keys()) | {paths[0] for paths in module_name_by_path.values()}
+    available_modules = (
+        set(module_name_by_path.keys())
+        | {paths[0] for paths in module_name_by_path.values()}
+        | {paths[0][:i] for paths in module_name_by_path.values() for i in range(1, len(paths[0]))}
+    )
     system_config.validate_modules(available_modules, config.environment.selected_modules_and_packages)
 
     selected_modules = config.get_selected_modules(system_config.packages, available_modules, verbose)

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -33,7 +33,7 @@ class Environment:
     name: str
     project: str
     build_type: str
-    selected_modules_and_packages: list[tuple[str]]
+    selected_modules_and_packages: list[tuple[str] | str]
     common_function_code: str
 
     @classmethod
@@ -44,7 +44,8 @@ class Environment:
                 project=data["project"],
                 build_type=data["type"],
                 selected_modules_and_packages=[
-                    selected.split(cls.seperator) for selected in data["selected_modules_and_packages"]
+                    selected.split(cls.seperator) if cls.seperator in selected else selected
+                    for selected in data["selected_modules_and_packages"]
                 ],
                 common_function_code=data.get("common_function_code", "./common_function_code"),
             )
@@ -61,7 +62,8 @@ class Environment:
             "project": self.project,
             "type": self.build_type,
             "selected_modules_and_packages": [
-                self.seperator.join(selected) for selected in self.selected_modules_and_packages
+                self.seperator.join(selected) if isinstance(selected, tuple) else selected
+                for selected in self.selected_modules_and_packages
             ],
             "common_function_code": self.common_function_code,
         }

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -161,6 +161,8 @@ class BuildConfigYAML(ConfigCore, ConfigYAMLCore):
         ]
         if verbose:
             print("  [bold green]INFO:[/] Selected packages:")
+            if len(selected_packages) == 0:
+                print("    None")
             for package in selected_packages:
                 print(f"    {package}")
 

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -8,7 +8,7 @@ from collections import UserDict, defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 import yaml
 from rich import print
@@ -29,10 +29,11 @@ from ._base import ConfigCore, _load_version_variable
 
 @dataclass
 class Environment:
+    seperator: ClassVar[str] = "/"
     name: str
     project: str
     build_type: str
-    selected_modules_and_packages: list[str]
+    selected_modules_and_packages: list[tuple[str]]
     common_function_code: str
 
     @classmethod
@@ -42,7 +43,9 @@ class Environment:
                 name=data["name"],
                 project=data["project"],
                 build_type=data["type"],
-                selected_modules_and_packages=data["selected_modules_and_packages"],
+                selected_modules_and_packages=[
+                    selected.split(cls.seperator) for selected in data["selected_modules_and_packages"]
+                ],
                 common_function_code=data.get("common_function_code", "./common_function_code"),
             )
         except KeyError:
@@ -57,7 +60,9 @@ class Environment:
             "name": self.name,
             "project": self.project,
             "type": self.build_type,
-            "selected_modules_and_packages": self.selected_modules_and_packages,
+            "selected_modules_and_packages": [
+                self.seperator.join(selected) for selected in self.selected_modules_and_packages
+            ],
             "common_function_code": self.common_function_code,
         }
 

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -33,7 +33,7 @@ class Environment:
     name: str
     project: str
     build_type: str
-    selected_modules_and_packages: list[tuple[str] | str]
+    selected_modules_and_packages: list[str | tuple[str, ...]]
     common_function_code: str
 
     @classmethod
@@ -81,8 +81,8 @@ class BuildConfigYAML(ConfigCore, ConfigYAMLCore):
     variables: dict[str, Any]
 
     @property
-    def available_modules(self) -> list[str]:
-        available_modules: list[str] = []
+    def available_modules(self) -> list[str | tuple[str, ...]]:
+        available_modules: list[str | tuple[str, ...]] = []
         to_check = [self.variables]
         while to_check:
             current = to_check.pop()
@@ -147,10 +147,15 @@ class BuildConfigYAML(ConfigCore, ConfigYAMLCore):
         )
 
     def get_selected_modules(
-        self, modules_by_package: dict[str, list[str]], available_modules: set[str], verbose: bool
-    ) -> list[str]:
+        self,
+        modules_by_package: dict[str, list[str | tuple[str, ...]]],
+        available_modules: set[str | tuple[str, ...]],
+        verbose: bool,
+    ) -> list[str | tuple[str, ...]]:
         selected_packages = [
-            package for package in self.environment.selected_modules_and_packages if package in modules_by_package
+            package
+            for package in self.environment.selected_modules_and_packages
+            if package in modules_by_package and isinstance(package, str)
         ]
         if verbose:
             print("  [bold green]INFO:[/] Selected packages:")

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -44,7 +44,7 @@ class Environment:
                 project=data["project"],
                 build_type=data["type"],
                 selected_modules_and_packages=[
-                    selected.split(MODULE_PATH_SEP) if MODULE_PATH_SEP in selected else selected
+                    tuple(selected.split(MODULE_PATH_SEP)) if MODULE_PATH_SEP in selected else selected
                     for selected in data["selected_modules_and_packages"]
                 ],
                 common_function_code=data.get("common_function_code", "./common_function_code"),

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -8,7 +8,7 @@ from collections import UserDict, defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, Literal, cast
 
 import yaml
 from rich import print
@@ -18,6 +18,7 @@ from cognite_toolkit._cdf_tk.load import LOADER_BY_FOLDER_NAME
 from cognite_toolkit._cdf_tk.templates._constants import (
     BUILD_ENVIRONMENT_FILE,
     DEFAULT_CONFIG_FILE,
+    MODULE_PATH_SEP,
     SEARCH_VARIABLES_SUFFIX,
 )
 from cognite_toolkit._cdf_tk.templates._utils import flatten_dict
@@ -29,7 +30,6 @@ from ._base import ConfigCore, _load_version_variable
 
 @dataclass
 class Environment:
-    seperator: ClassVar[str] = "/"
     name: str
     project: str
     build_type: str
@@ -44,7 +44,7 @@ class Environment:
                 project=data["project"],
                 build_type=data["type"],
                 selected_modules_and_packages=[
-                    selected.split(cls.seperator) if cls.seperator in selected else selected
+                    selected.split(MODULE_PATH_SEP) if MODULE_PATH_SEP in selected else selected
                     for selected in data["selected_modules_and_packages"]
                 ],
                 common_function_code=data.get("common_function_code", "./common_function_code"),
@@ -62,7 +62,7 @@ class Environment:
             "project": self.project,
             "type": self.build_type,
             "selected_modules_and_packages": [
-                self.seperator.join(selected) if isinstance(selected, tuple) else selected
+                MODULE_PATH_SEP.join(selected) if isinstance(selected, tuple) else selected
                 for selected in self.selected_modules_and_packages
             ],
             "common_function_code": self.common_function_code,

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -44,7 +44,9 @@ class Environment:
                 project=data["project"],
                 build_type=data["type"],
                 selected_modules_and_packages=[
-                    tuple(selected.split(MODULE_PATH_SEP)) if MODULE_PATH_SEP in selected else selected
+                    tuple([part for part in selected.split(MODULE_PATH_SEP) if part])
+                    if MODULE_PATH_SEP in selected
+                    else selected
                     for selected in data["selected_modules_and_packages"]
                 ],
                 common_function_code=data.get("common_function_code", "./common_function_code"),

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -180,7 +180,10 @@ class BuildConfigYAML(ConfigCore, ConfigYAMLCore):
         if verbose:
             print("  [bold green]INFO:[/] Selected modules:")
             for module in selected_modules:
-                print(f"    {MODULE_PATH_SEP.join(module)!s}")
+                if isinstance(module, str):
+                    print(f"    {module}")
+                else:
+                    print(f"    {MODULE_PATH_SEP.join(module)!s}")
         if not selected_modules:
             print(
                 f"  [bold yellow]WARNING:[/] Found no defined modules in {self.filepath!s}, have you configured the environment ({self.environment.name})?"

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_config_yaml.py
@@ -178,7 +178,7 @@ class BuildConfigYAML(ConfigCore, ConfigYAMLCore):
         if verbose:
             print("  [bold green]INFO:[/] Selected modules:")
             for module in selected_modules:
-                print(f"    {module}")
+                print(f"    {MODULE_PATH_SEP.join(module)!s}")
         if not selected_modules:
             print(
                 f"  [bold yellow]WARNING:[/] Found no defined modules in {self.filepath!s}, have you configured the environment ({self.environment.name})?"

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
@@ -30,7 +30,7 @@ class SystemYAML(ConfigCore):
             filepath=filepath,
             cdf_toolkit_version=version,
             packages={
-                name: [entry.split(MODULE_PATH_SEP) if MODULE_PATH_SEP in entry else entry for entry in package]
+                name: [tuple(entry.split(MODULE_PATH_SEP)) if MODULE_PATH_SEP in entry else entry for entry in package]
                 for name, package in packages.items()
             },
         )
@@ -38,7 +38,11 @@ class SystemYAML(ConfigCore):
     def validate_modules(
         self, available_modules: set[str | tuple[str, ...]], selected_modules_and_packages: list[str | tuple[str, ...]]
     ) -> None:
-        selected_packages = {package for package in selected_modules_and_packages if package in self.packages}
+        selected_packages = {
+            package
+            for package in selected_modules_and_packages
+            if package in self.packages and isinstance(package, str)
+        }
         for package, modules in self.packages.items():
             if package not in selected_packages:
                 # We do not check packages that are not selected.

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
@@ -30,7 +30,12 @@ class SystemYAML(ConfigCore):
             filepath=filepath,
             cdf_toolkit_version=version,
             packages={
-                name: [tuple(entry.split(MODULE_PATH_SEP)) if MODULE_PATH_SEP in entry else entry for entry in package]
+                name: [
+                    tuple([part for part in entry.split(MODULE_PATH_SEP) if part])
+                    if MODULE_PATH_SEP in entry
+                    else entry
+                    for entry in package
+                ]
                 for name, package in packages.items()
             },
         )

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar
 
 from rich import print
 
+from cognite_toolkit._cdf_tk.templates._constants import MODULE_PATH_SEP
 from cognite_toolkit._cdf_tk.templates.data_classes._base import ConfigCore, _load_version_variable
 
 
@@ -13,7 +14,7 @@ from cognite_toolkit._cdf_tk.templates.data_classes._base import ConfigCore, _lo
 class SystemYAML(ConfigCore):
     file_name: ClassVar[str] = "_system.yaml"
     cdf_toolkit_version: str
-    packages: dict[str, list[str]] = field(default_factory=dict)
+    packages: dict[str, list[str | tuple[str]]] = field(default_factory=dict)
 
     @classmethod
     def _file_name(cls, build_env: str) -> str:
@@ -28,10 +29,15 @@ class SystemYAML(ConfigCore):
         return cls(
             filepath=filepath,
             cdf_toolkit_version=version,
-            packages=packages,
+            packages={
+                name: [entry.split(MODULE_PATH_SEP) if MODULE_PATH_SEP in entry else entry for entry in package]
+                for name, package in packages.items()
+            },
         )
 
-    def validate_modules(self, available_modules: set[str], selected_modules_and_packages: list[str]) -> None:
+    def validate_modules(
+        self, available_modules: set[str | tuple[str]], selected_modules_and_packages: list[str | tuple[str]]
+    ) -> None:
         selected_packages = {package for package in selected_modules_and_packages if package in self.packages}
         for package, modules in self.packages.items():
             if package not in selected_packages:

--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_system_yaml.py
@@ -14,7 +14,7 @@ from cognite_toolkit._cdf_tk.templates.data_classes._base import ConfigCore, _lo
 class SystemYAML(ConfigCore):
     file_name: ClassVar[str] = "_system.yaml"
     cdf_toolkit_version: str
-    packages: dict[str, list[str | tuple[str]]] = field(default_factory=dict)
+    packages: dict[str, list[str | tuple[str, ...]]] = field(default_factory=dict)
 
     @classmethod
     def _file_name(cls, build_env: str) -> str:
@@ -36,7 +36,7 @@ class SystemYAML(ConfigCore):
         )
 
     def validate_modules(
-        self, available_modules: set[str | tuple[str]], selected_modules_and_packages: list[str | tuple[str]]
+        self, available_modules: set[str | tuple[str, ...]], selected_modules_and_packages: list[str | tuple[str, ...]]
     ) -> None:
         selected_packages = {package for package in selected_modules_and_packages if package in self.packages}
         for package, modules in self.packages.items():

--- a/tests/tests_unit/test_behavior.py
+++ b/tests/tests_unit/test_behavior.py
@@ -69,8 +69,8 @@ def test_duplicated_modules(local_tmp_path: Path, typer_context: typer.Context, 
             system_config=MagicMock(spec=SystemYAML),
         )
     # Check that the error message is printed
-    assert "module1" in capture_print.messages[-1]
-    assert "duplicated module names" in capture_print.messages[-2]
+    assert "module1" in capture_print.messages[-2]
+    assert "duplicated module names" in capture_print.messages[-3]
 
 
 def test_pull_transformation(

--- a/tests/tests_unit/test_behavior.py
+++ b/tests/tests_unit/test_behavior.py
@@ -14,7 +14,7 @@ from cognite_toolkit._cdf_tk.templates import build_config
 from cognite_toolkit._cdf_tk.templates.data_classes import BuildConfigYAML, SystemYAML
 from cognite_toolkit._cdf_tk.utils import CDFToolConfig
 from tests.tests_unit.approval_client import ApprovalCogniteClient
-from tests.tests_unit.test_cdf_tk.constants import CUSTOM_PROJECT, PROJECT_WITH_DUPLICATES
+from tests.tests_unit.test_cdf_tk.constants import CUSTOM_PROJECT, PROJECT_WITH_DUPLICATES, PYTEST_PROJECT
 from tests.tests_unit.utils import PrintCapture, mock_read_yaml_file
 
 
@@ -249,6 +249,28 @@ def test_build_custom_project(
     build(
         typer_context,
         source_dir=str(CUSTOM_PROJECT),
+        build_dir=str(local_tmp_path),
+        build_env="dev",
+        no_clean=False,
+    )
+
+    actual_resources = {path.name for path in local_tmp_path.iterdir() if path.is_dir()}
+
+    missing_resources = expected_resources - actual_resources
+    assert not missing_resources, f"Missing resources: {missing_resources}"
+
+    extra_resources = actual_resources - expected_resources
+    assert not extra_resources, f"Extra resources: {extra_resources}"
+
+
+def test_build_project_selecting_parent_path(
+    local_tmp_path,
+    typer_context,
+) -> None:
+    expected_resources = {"auth", "data_models", "files", "transformations"}
+    build(
+        typer_context,
+        source_dir=str(PYTEST_PROJECT),
         build_dir=str(local_tmp_path),
         build_env="dev",
         no_clean=False,

--- a/tests/tests_unit/test_cdf_tk/project_for_test/config.dev.yaml
+++ b/tests/tests_unit/test_cdf_tk/project_for_test/config.dev.yaml
@@ -3,8 +3,7 @@ environment:
   project: <customer-dev>
   type: dev
   selected_modules_and_packages:
-    - cdf_demo_infield
-    - cdf_oid_example_data
+    - cognite_modules/
 
 variables:
   cognite_modules:

--- a/tests/tests_unit/test_cdf_tk/project_no_cognite_modules/config.dev.yaml
+++ b/tests/tests_unit/test_cdf_tk/project_no_cognite_modules/config.dev.yaml
@@ -3,8 +3,8 @@ environment:
   project: some-project
   type: dev
   selected_modules_and_packages:
-    - a_module
-    - another_module
+    - modules/a_module
+    - modules/another_module
 
 variables:
   modules:


### PR DESCRIPTION
# Description

- Support for specifying `selected_modules_and_packages` as paths and parent paths. For example, you can
  now write `cognite_modules/core/cdf_apm_base` instead of just `cdf_apm_base`. This is to support
  modules that have the same name but are in different parent directories. In addition, this also better reflects
  the structure of the `cognite_modules` and `custom_modules` folder.


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
