### PR TITLE
Migration: Handle moved system.yaml

### DIFF
--- a/cognite_toolkit/_cdf_tk/templates/data_classes/_base.py
+++ b/cognite_toolkit/_cdf_tk/templates/data_classes/_base.py
@@ -28,7 +28,18 @@ class ConfigCore(ABC):
         file_name = cls._file_name(build_env)
         filepath = source_path / file_name
         filepath = filepath if filepath.is_file() else Path.cwd() / file_name
-        if not filepath.is_file():
+        if (
+            (old_filepath := (source_path / "cognite_modules" / file_name)).is_file()
+            and not filepath.is_file()
+            and file_name == "_system.yaml"
+        ):
+            # This is a fallback for the old location of the system file
+            print(
+                f"  [bold yellow]Warning:[/] {filepath.name!r} does not exist. "
+                f"Using 'cognite_toolkit/{old_filepath.name}' instead."
+            )
+            filepath = old_filepath
+        elif not filepath.is_file():
             print(f"  [bold red]ERROR:[/] {filepath.name!r} does not exist")
             exit(1)
         return cls.load(read_yaml_file(filepath), build_env, filepath)


### PR DESCRIPTION
# Description

Currently you are met with the unhelpful message after updating the toolkit to the current version in main. This ensures that it is loaded from the old location such that appropriate migration steps can be displayed to the user.

```
cdf-tk build
  ERROR: '_system.yaml' does not exist
```

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
