### PR TITLE
Setting canonical base url

### DIFF
--- a/cognite_toolkit/_cdf_tk/load/_base_loaders.py
+++ b/cognite_toolkit/_cdf_tk/load/_base_loaders.py
@@ -63,7 +63,7 @@ class Loader(ABC):
     filename_pattern: str = ""
     dependencies: frozenset[type[ResourceLoader]] = frozenset()
     exclude_filetypes: frozenset[str] = frozenset()
-    _doc_base_url: str = "https://developer.cognite.com/api#tag/"
+    _doc_base_url: str = "https://api-docs.cognite.com/20230101/tag/"
     _doc_url: str = ""
 
     def __init__(self, client: CogniteClient, build_path: Path | None = None):


### PR DESCRIPTION
# Description

Maybe against better judgment, changing the base url to one that can be tested for correct HTTP status codes but may become obsolete. 


## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
