### PR TITLE
[CDF-20990] Cleanup temporarily build directory 🧹

### DIFF
--- a/CHANGELOG.cdf-tk.md
+++ b/CHANGELOG.cdf-tk.md
@@ -23,6 +23,7 @@ Changes are grouped as follows:
   missing a required field.
 - Transformation queries can be inline, i.e. set in either the Transformation `query` property in the yaml or
   as a separate file. If set in both, an error is raised because it is ambiguous which query to use.
+- In the `cdf-tk pull` command, if an error occurs, the temporary directory was not removed. This is now fixed.
 
 ## [0.2.0a4] - 2024-04-29
 

--- a/cognite_toolkit/_cdf_tk/utils.py
+++ b/cognite_toolkit/_cdf_tk/utils.py
@@ -22,12 +22,15 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
+import tempfile
 import types
 import typing
 from abc import abstractmethod
 from collections import UserDict, UserList, defaultdict
 from collections.abc import Collection, ItemsView, KeysView, Sequence, ValuesView
+from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
 from functools import total_ordering
 from pathlib import Path
@@ -1371,3 +1374,12 @@ def sentry_exception_filter(event: SentryEvent, hint: SentryHint) -> Optional[Se
         if isinstance(exc_value, ToolkitError):
             return None
     return event
+
+
+@contextmanager
+def tmp_build_directory() -> typing.Generator[Path, None, None]:
+    build_dir = Path(tempfile.mkdtemp(prefix="build.", suffix=".tmp", dir=Path.cwd()))
+    try:
+        yield build_dir
+    finally:
+        shutil.rmtree(build_dir)


### PR DESCRIPTION
# Description

There is also a temporary directory when you use the `cdf-tk init --upgrade` command, but that is never deleted which I think is intentional. As it is up to the user to cleanup when she/he is happy with the upgrade.

## Checklist

- [ ] Tests added/updated.
- [ ] Run Demo Job Locally.
- [ ] Documentation updated.
- [ ] Changelogs updated in [CHANGELOG.cdf-tk.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.cdf-tk.md).
- [ ] Template changelogs updated in [CHANGELOG.templates.md](https://github.com/cognitedata/cdf-project-templates/blob/main/CHANGELOG.templates.md).
- [ ] Version bumped.
  [_version.py](https://github.com/cognitedata/cdf-project-templates/blob/main/cognite/cognite_toolkit/_version.py) and
  [pyproject.toml](https://github.com/cognitedata/cdf-project-templates/blob/main/pyproject.toml) per [semantic versioning](https://semver.org/).
